### PR TITLE
Fix UNAUTHENTICATED mode

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -456,7 +456,7 @@ const app = new Elysia({
         }
       }
     } else if (ALLOW_UNAUTHENTICATED) {
-      const newUserId = String(randomInt(2 ** 24, Number.MAX_SAFE_INTEGER));
+      const newUserId = String(randomInt(2 ** 24, Math.min(2 ** 48 + 2 ** 24 - 1,  Number.MAX_SAFE_INTEGER)));
       const accessToken = await jwt.sign({
         id: newUserId,
       });


### PR DESCRIPTION
the function used here, randmInt(Min, Max) has an issue. When running the code, I get a 500 error, with the error being 

```
 |       const newUserId = String(randomInt(2 ** 24,  Number.MAX_SAFE_INTEGER));
      ^
RangeError: The "max - min" is out of range. It must be <= 281474976710655. Received 9007199237963775
 code: "ERR_OUT_OF_RANGE"

      at randomInt (native:1:1)
      at /.../ConvertX/src/index.tsx:460:32
      at /.../ConvertX/src/index.tsx:594:29
      at file:///.../ConvertX/node_modules/elysia/dist/bun/index.js:76:22
```

When digging deeper in the implementation, it seems that the official node doc says : 
> The range (max - min) must be less than 2**48. min and max must be safe integers.

See : https://nodejs.org/api/crypto.html#cryptorandomintmin-max-callback

Feel free to close this PR and do the fix another way (it: by using a uuid instead of randomInt, etc.)