### PR TITLE
[FIX] Fix broken CSS

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,10 +1,9 @@
 /** @type {import('tailwindcss').Config} */
-import scrollbar from 'tailwind-scrollbar';
 // eslint-disable-next-line no-undef
 module.exports = {
-  content: ["./src/**/*.{html,js,tsx,jsx,cjs,mjs}"],
+  content: ['./src/**/*.{html,js,tsx,jsx,cjs,mjs}'],
   theme: {
     extend: {},
   },
-  plugins: [scrollbar()],
+  plugins: [require('tailwind-scrollbar')],
 }


### PR DESCRIPTION
This is a fix for #141 
The CSS was broken due to the import in the tailwind.config.js, it should be inside the module.exports and not outside. Thats why bun was giving a warning before :

```
# bun run dev
warn - The `content` option in your Tailwind CSS configuration is missing or empty.
warn - Configure your content sources or your generated CSS will be missing styles.
warn - https://tailwindcss.com/docs/content-configuration
```

it is now fixed