### PR TITLE
Fixed example docker-compose.yml file

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ services:
     environment:
       - JWT_SECRET=aLongAndSecretStringUsedToSignTheJSONWebToken1234 # will use randomUUID() if unset
     volumes:
-      - convertx:/app/data
+      - ./data:/app/data
 ```
 
 or


### PR DESCRIPTION
I was not able to run the example docker-compose.yml file since it's looking for the "convertx" volume which would need to be defined in the "volumes" tag. Instead, I changed it so it matches the normal docker command below with a direct folder binding of `./data` to `/app/data`. Maybe it was working in an older version of docker compose but I can't get it to work on my machine. Let me know what you think.

Development Machine specs:
- Windows 10 Pro
- Docker Desktop 4.37.1 (178610)
- Docker Compose version v2.31.0-desktop.2

## Summary by Sourcery

Bug Fixes:
- Fixed the example `docker-compose.yml` file to mount the correct data volume.