### PR TITLE
fix: add libheif

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,13 +49,16 @@ RUN apk --no-cache add  \
   vips-tools \
   vips-poppler \
   vips-jxl \
+  vips-heif \
+  vips-magick \
   libjxl-tools \
   assimp \
   inkscape \
   poppler-utils \
   gcompat \
   libva-utils \
-  py3-numpy
+  py3-numpy \
+  libheif-tools
 
 RUN apk --no-cache add qt6-qtbase-private-dev --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community/
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ A self-hosted online file converter. Supports over a thousand different formats.
 |------------------------------------------------------------------------------|---------------|---------------|-------------|
 | [libjxl](https://github.com/libjxl/libjxl)                                   | JPEG XL       | 11            | 11          |
 | [resvg](https://github.com/RazrFalcon/resvg)                                 | SVG           | 1             | 1           |
+| [libheif](https://github.com/strukturag/libheif)                             | HEIF          | 7             | 6           |
 | [Vips](https://github.com/libvips/libvips)                                   | Images        | 45            | 23          |
 | [XeLaTeX](https://tug.org/xetex/)                                            | LaTeX         | 1             | 1           |
 | [Calibre](https://calibre-ebook.com/)                                        | E-books       | 26            | 19          |

--- a/src/converters/libheif.ts
+++ b/src/converters/libheif.ts
@@ -1,0 +1,52 @@
+import { execFile } from "child_process";
+
+export const properties = {
+  from: {
+    images: [
+      "avci",
+      "avcs",
+      "avif",
+      "h264",
+      "heic",
+      "heics",
+      "heif",
+      "heifs",
+      "mkv",
+      "mp4",
+    ],
+  },
+  to: {
+    images: ["jpeg", "png", "y4m"],
+  },
+};
+
+export function convert(
+  filePath: string,
+  fileType: string,
+  convertTo: string,
+  targetPath: string,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  options?: unknown,
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      "heif-convert",
+      [filePath, targetPath],
+      (error, stdout, stderr) => {
+        if (error) {
+          reject(`error: ${error}`);
+        }
+
+        if (stdout) {
+          console.log(`stdout: ${stdout}`);
+        }
+
+        if (stderr) {
+          console.error(`stderr: ${stderr}`);
+        }
+
+        resolve("Done");
+      },
+    );
+  });
+}

--- a/src/converters/main.ts
+++ b/src/converters/main.ts
@@ -9,6 +9,7 @@ import { convert as convertresvg, properties as propertiesresvg } from "./resvg"
 import { convert as convertImage, properties as propertiesImage } from "./vips";
 import { convert as convertxelatex, properties as propertiesxelatex } from "./xelatex";
 import { convert as convertCalibre, properties as propertiesCalibre } from "./calibre";
+import { convert as convertLibheif, properties as propertiesLibheif } from "./libheif";
 
 
 // This should probably be reconstructed so that the functions are not imported instead the functions hook into this to make the converters more modular
@@ -48,6 +49,10 @@ const properties: Record<
   resvg: {
     properties: propertiesresvg,
     converter: convertresvg,
+  },
+  libheif: {
+    properties: propertiesLibheif,
+    converter: convertLibheif,
   },
   vips: {
     properties: propertiesImage,


### PR DESCRIPTION
issue #202

## Summary by Sourcery

Add support for HEIF image conversion. This includes installing the necessary libraries (libheif, libheif-tools, and vips-heif) in the Docker image, implementing the conversion logic, and updating the documentation.

New Features:
- Add support for converting HEIF images using libheif

Build:
- Add libheif, libheif-tools, and vips-heif to the docker image

Documentation:
- Document HEIF support and update supported conversion formats in the README