### PR TITLE
Added progress bar for file upload

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -160,10 +160,8 @@ fileInput.addEventListener("change", (e) => {
 
     // Append the file to the hidden input
     fileNames.push(file.name);
-  }
 
-  for (const file of files) {
-    uploadFiles([file]);
+    uploadFile(file);
   }
 });
 
@@ -204,16 +202,13 @@ const deleteRow = (target) => {
     .catch((err) => console.log(err));
 };
 
-const uploadFiles = (files) => {
+const uploadFile = (file) => {
   convertButton.disabled = true;
   convertButton.textContent = "Uploading...";
   pendingFiles += 1;
 
   const formData = new FormData();
-
-  for (const file of files) {
-    formData.append("file", file, file.name);
-  }
+  formData.append("file", file, file.name);
 
   let xhr = new XMLHttpRequest(); 
 
@@ -231,24 +226,18 @@ const uploadFiles = (files) => {
     }
 
     //Remove the progress bar when upload is done
-    for (const file of files) {
-      let progressbar = file.htmlRow.getElementsByTagName("progress");
-      progressbar[0].parentElement.remove();
-    }
+    let progressbar = file.htmlRow.getElementsByTagName("progress");
+    progressbar[0].parentElement.remove();
     console.log(data);
   };
 
   xhr.upload.onprogress = (e) => {
-    //All files upload together are binded by the same progress. The loop should probably be on the call to this function (uploadFiles) to track each upload individually.
-    //This will consequently only allow a single file uploaded per request.
     let sent = e.loaded;
     let total = e.total;
-    console.log(`upload progress (${files[0].name}):`, (100 * sent) / total);
+    console.log(`upload progress (${file.name}):`, (100 * sent) / total);
 
-    for (const file of files) {
-      let progressbar = file.htmlRow.getElementsByTagName("progress");
-      progressbar[0].value = ((100 * sent) / total);
-    }
+    let progressbar = file.htmlRow.getElementsByTagName("progress");
+    progressbar[0].value = ((100 * sent) / total);
   };
 
   xhr.onerror = (e) => {

--- a/public/script.js
+++ b/public/script.js
@@ -162,7 +162,9 @@ fileInput.addEventListener("change", (e) => {
     fileNames.push(file.name);
   }
 
-  uploadFiles(files);
+  for (const file of files) {
+    uploadFiles([file]);
+  }
 });
 
 const setTitle = () => {
@@ -237,16 +239,17 @@ const uploadFiles = (files) => {
   };
 
   xhr.upload.onprogress = (e) => {
-      //All files upload together are binded by the same progress. The loop should probably be on the call to this function to track each upload individually.
-      let sent = e.loaded;
-      let total = e.total;
-      console.log("upload progress:", (100 * sent) / total);
+    //All files upload together are binded by the same progress. The loop should probably be on the call to this function (uploadFiles) to track each upload individually.
+    //This will consequently only allow a single file uploaded per request.
+    let sent = e.loaded;
+    let total = e.total;
+    console.log(`upload progress (${files[0].name}):`, (100 * sent) / total);
 
-      for (const file of files) {
-        let progressbar = file.htmlRow.getElementsByTagName("progress");
-        progressbar[0].value = ((100 * sent) / total);
-      }
-    };
+    for (const file of files) {
+      let progressbar = file.htmlRow.getElementsByTagName("progress");
+      progressbar[0].value = ((100 * sent) / total);
+    }
+  };
 
   xhr.onerror = (e) => {
     console.log(e);

--- a/public/script.js
+++ b/public/script.js
@@ -118,6 +118,7 @@ fileInput.addEventListener("change", (e) => {
     const row = document.createElement("tr");
     row.innerHTML = `
       <td>${file.name}</td>
+      <td><progress max="100"></progress></td>
       <td>${(file.size / 1024).toFixed(2)} kB</td>
       <td><a onclick="deleteRow(this)">Remove</a></td>
     `;
@@ -152,6 +153,10 @@ fileInput.addEventListener("change", (e) => {
 
     // Append the row to the file-list table
     fileList.appendChild(row);
+
+    //Imbed row into the file to reference later
+    file.htmlRow = row;
+
 
     // Append the file to the hidden input
     fileNames.push(file.name);
@@ -208,22 +213,42 @@ const uploadFiles = (files) => {
     formData.append("file", file, file.name);
   }
 
-  fetch(`${webroot}/upload`, {
-    method: "POST",
-    body: formData,
-  })
-    .then((res) => res.json())
-    .then((data) => {
-      pendingFiles -= 1;
-      if (pendingFiles === 0) {
-        if (formatSelected) {
-          convertButton.disabled = false;
-        }
-        convertButton.textContent = "Convert";
+  let xhr = new XMLHttpRequest(); 
+
+  xhr.open("POST", `${webroot}/upload`, true);
+
+  xhr.onload = (e) => {
+    let data = JSON.parse(xhr.responseText);
+
+    pendingFiles -= 1;
+    if (pendingFiles === 0) {
+      if (formatSelected) {
+        convertButton.disabled = false;
       }
-      console.log(data);
-    })
-    .catch((err) => console.log(err));
+      convertButton.textContent = "Convert";
+    }
+
+    //Remove the progress bar when upload is done
+    for (const file of files) {
+      let progressbar = file.htmlRow.getElementsByTagName("progress");
+      progressbar[0].parentElement.remove();
+    }
+    console.log(data);
+  };
+
+  xhr.upload.onprogress = (e) => {
+      //All files upload together are binded by the same progress. The loop should probably be on the call to this function to track each upload individually.
+      let sent = e.loaded;
+      let total = e.total;
+      console.log("upload progress:", (100 * sent) / total);
+
+      for (const file of files) {
+        let progressbar = file.htmlRow.getElementsByTagName("progress");
+        progressbar[0].value = ((100 * sent) / total);
+      }
+    };
+
+  xhr.send(formData);
 };
 
 const formConvert = document.querySelector(`form[action='${webroot}/convert']`);

--- a/public/script.js
+++ b/public/script.js
@@ -248,6 +248,10 @@ const uploadFiles = (files) => {
       }
     };
 
+  xhr.onerror = (e) => {
+    console.log(e);
+  };
+
   xhr.send(formData);
 };
 


### PR DESCRIPTION
I added a progress bar to uploaded files.
The progress bar is implemented kind of crudely right now. I had to change the fetch() method used for the upload to the traditional XMLHttpRequest() since fetch only support viewing the stream on HTTP/2 request. I didn't want to implement HTTP/2 (and https) since Elysia doesn't since to support it right now (Bun only started to support it like a month ago anyway).
I'm sure this could be modernize later on.

I'm gonna mark this has a draft right now since i implemented this in like an hour and want to make sure i didn't miss an edge case. Probably going to test it more tomorrow or in the coming days.

Let me know what you think!

## Summary by Sourcery

New Features:
- Implement a progress bar for file uploads, providing visual feedback during the upload process.