### PR TITLE
chore: downgrade bun to 1.2.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM oven/bun:1.2.4-alpine AS base
+FROM oven/bun:1.2.3-alpine AS base
 LABEL org.opencontainers.image.source="https://github.com/C4illin/ConvertX"
 WORKDIR /app
 


### PR DESCRIPTION
issue #235 
## Summary by Sourcery

Chores:
- Downgrade bun to 1.2.3.