### PR TITLE
fix: change to canary bun

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM oven/bun:1.2.2-alpine AS base
+FROM oven/bun:canary-alpine AS base
 LABEL org.opencontainers.image.source="https://github.com/C4illin/ConvertX"
 WORKDIR /app
 


### PR DESCRIPTION
issue: #235

## Summary by Sourcery

Chores:
- Update the base Docker image to use the canary version of Bun.