### PR TITLE
Add potrace converter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,8 @@ RUN apk --no-cache add  \
   poppler-utils \
   gcompat \
   libva-utils \
-  py3-numpy
+  py3-numpy \
+  potrace
 
 # RUN apk --no-cache add calibre@testing --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main/
 

--- a/src/converters/main.ts
+++ b/src/converters/main.ts
@@ -10,6 +10,7 @@ import { convert as convertImage, properties as propertiesImage } from "./vips";
 import { convert as convertxelatex, properties as propertiesxelatex } from "./xelatex";
 // import { convert as convertCalibre, properties as propertiesCalibre } from "./calibre";
 import { convert as convertLibheif, properties as propertiesLibheif } from "./libheif";
+import { convert as convertpotrace, properties as propertiespotrace } from "./potrace";
 
 
 // This should probably be reconstructed so that the functions are not imported instead the functions hook into this to make the converters more modular
@@ -85,6 +86,10 @@ const properties: Record<
   ffmpeg: {
     properties: propertiesFFmpeg,
     converter: convertFFmpeg,
+  },
+  potrace: {
+    properties: propertiespotrace,
+    converter: convertpotrace,
   },
 };
 

--- a/src/converters/potrace.ts
+++ b/src/converters/potrace.ts
@@ -1,0 +1,37 @@
+import { execFile } from "node:child_process";
+
+export const properties = {
+  from: {
+    images: ["pnm", "pbm", "pgm", "bmp"],
+  },
+  to: {
+    images: ["svg", "pdf", "pdfpage", "eps", "postscript", "ps", "dxf", "geojson", "pgm", "gimppath", "xfig"],
+  },
+};
+
+export function convert(
+    filePath: string,
+    fileType: string,
+    convertTo: string,
+    targetPath: string,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    options?: unknown,
+  ): Promise<string> {
+    return new Promise((resolve, reject) => {
+      execFile("potrace", [filePath, "-o", targetPath, "-b", convertTo], (error, stdout, stderr) => {
+        if (error) {
+          reject(`error: ${error}`);
+        }
+  
+        if (stdout) {
+          console.log(`stdout: ${stdout}`);
+        }
+  
+        if (stderr) {
+          console.error(`stderr: ${stderr}`);
+        }
+  
+        resolve("Done");
+      });
+    });
+  }

--- a/src/helpers/printVersions.ts
+++ b/src/helpers/printVersions.ts
@@ -124,6 +124,16 @@ if (process.env.NODE_ENV === "production") {
     }
   });
 
+  exec("potrace -v", (error, stdout) => {
+    if (error) {
+      console.error("potrace is not installed");
+    }
+
+    if (stdout) {
+      console.log(stdout.split("\n")[0]);
+    }
+  });
+
   exec("bun -v", (error, stdout) => {
     if (error) {
       console.error("Bun is not installed. wait what");


### PR DESCRIPTION
Add [potrace](https://potrace.sourceforge.net/) converter for bitmap to vector formats.

Think I got everything right here... I tested with some of the example potrace images found [here](https://potrace.sourceforge.net/samples.html)

Great tool!

## Summary by Sourcery

Add potrace converter to support converting bitmap images to various vector formats

New Features:
- Implement potrace converter for converting bitmap images to vector formats like SVG, PDF, EPS, and others

Enhancements:
- Extend converter system to include potrace as a new conversion option

Deployment:
- Add potrace package to Dockerfile dependencies