### PR TITLE
feat: Add support for .HIF files

### DIFF
--- a/src/converters/libheif.ts
+++ b/src/converters/libheif.ts
@@ -11,6 +11,7 @@ export const properties = {
       "heics",
       "heif",
       "heifs",
+      "hif",
       "mkv",
       "mp4",
     ],


### PR DESCRIPTION
[HIF files](https://fileinfo.com/extension/hif) use the HEIF format in the HEIX variant and have support for extended color profiles. Sony cameras for example will output these files. They are already supported by libheif so it's just a matter of adding the file extension to this project.