### PR TITLE
Add account management page

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -37,6 +37,19 @@ export const Header = ({
                 text-accent-600 transition-all
                 hover:text-accent-500 hover:underline
               `}
+              href={`${webroot}/account`}
+            >
+              Account
+            </a>
+          </li>
+        ) : null}
+        {!allowUnauthenticated ? (
+          <li>
+            <a
+              class={`
+                text-accent-600 transition-all
+                hover:text-accent-500 hover:underline
+              `}
               href={`${webroot}/logoff`}
             >
               Logout

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -615,7 +615,7 @@ const app = new Elysia({
         values.push(await Bun.password.hash(body.newPassword));
       }
 
-      if (fields.length < 1) {
+      if (fields.length > 0) {
         db.query(
           `UPDATE users SET ${fields.map((field) => `${field}=?`).join(", ")} WHERE id=?`,
         ).run(...values, user.id);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -599,6 +599,14 @@ const app = new Elysia({
       const values = [];
 
       if (body.email) {
+        // Enforce unique email constraint
+        const existingUser = await db.query(
+          "SELECT id FROM users WHERE email = ?",
+        ).get(body.email);
+        if (existingUser && existingUser.id !== user.id) {
+          set.status = 409;
+          return { message: "Email already in use." };
+        }
         fields.push("email");
         values.push(body.email);
       }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -531,7 +531,7 @@ const app = new Elysia({
                       name="newPassword"
                       class="rounded-sm bg-neutral-800 p-3"
                       placeholder="Password"
-                      autocomplete="current-password"
+                      autocomplete="new-password"
                     />
                   </label>
                   <label class="flex flex-col gap-1">


### PR DESCRIPTION
This adds a page that allows you to change your email & password.

## Summary by Sourcery

Add an account management page and supporting endpoints for authenticated users to update their email and password, and expose the page via the navigation header.

New Features:
- Introduce GET /account route to render a form for updating email and password.
- Implement POST /account handler to validate current password and persist email and password changes to the database.

Chores:
- Add an "Account" link to the header menu for authenticated users.

## Summary by Sourcery

Add an account management page and endpoints to let authenticated users update their email and password

New Features:
- Introduce GET /account endpoint to render a form for updating email and password
- Implement POST /account endpoint to verify current password, enforce email uniqueness, hash new passwords, and persist changes

Enhancements:
- Add an "Account" link to the navigation header for authenticated users