### PR TITLE
fix: switch from alpine to debian trixie

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ A self-hosted online file converter. Supports over a thousand different formats.
 | [Vips](https://github.com/libvips/libvips)                                   | Images        | 45            | 23          |
 | [libheif](https://github.com/strukturag/libheif)                             | HEIF          | 2             | 4           |
 | [XeLaTeX](https://tug.org/xetex/)                                            | LaTeX         | 1             | 1           |
+| [Calibre](https://calibre-ebook.com/)                                        | E-books       | 26            | 19          |
 | [Pandoc](https://pandoc.org/)                                                | Documents     | 43            | 65          |
 | [GraphicsMagick](http://www.graphicsmagick.org/)                             | Images        | 167           | 130         |
 | [Inkscape](https://inkscape.org/)                                            | Vector images | 7             | 17          |
@@ -38,7 +39,6 @@ A self-hosted online file converter. Supports over a thousand different formats.
 | [FFmpeg](https://ffmpeg.org/)                                                | Video         | ~472          | ~199        |
 | [Potrace](https://potrace.sourceforge.net/)                                  | Raster to vector | 4          | 11          |
 
-<!-- | [Calibre](https://calibre-ebook.com/)                                        | E-books       | 26            | 19          | -->
 
 <!-- many ffmpeg fileformats are duplicates -->
 

--- a/src/converters/main.ts
+++ b/src/converters/main.ts
@@ -8,7 +8,7 @@ import { convert as convertPandoc, properties as propertiesPandoc } from "./pand
 import { convert as convertresvg, properties as propertiesresvg } from "./resvg";
 import { convert as convertImage, properties as propertiesImage } from "./vips";
 import { convert as convertxelatex, properties as propertiesxelatex } from "./xelatex";
-// import { convert as convertCalibre, properties as propertiesCalibre } from "./calibre";
+import { convert as convertCalibre, properties as propertiesCalibre } from "./calibre";
 import { convert as convertLibheif, properties as propertiesLibheif } from "./libheif";
 import { convert as convertpotrace, properties as propertiespotrace } from "./potrace";
 
@@ -63,10 +63,10 @@ const properties: Record<
     properties: propertiesxelatex,
     converter: convertxelatex,
   },
-  // calibre: {
-  //   properties: propertiesCalibre,
-  //   converter: convertCalibre,
-  // },
+  calibre: {
+    properties: propertiesCalibre,
+    converter: convertCalibre,
+  },
   pandoc: {
     properties: propertiesPandoc,
     converter: convertPandoc,


### PR DESCRIPTION
issue: #234, #199

## Summary by Sourcery

Switch the Docker image base from Alpine to Debian Trixie slim and update all dependency installations to use apt-get while installing required tools and cleaning up caches.

Enhancements:
- Remove the separate Rust builder stage and install resvg and other tools directly via apt.
- Expand and update the list of runtime utilities (assimp-utils, calibre, dcraw, graphicsmagick, inkscape, python3-numpy, texlive, etc.).

Build:
- Switch Docker base image from Alpine to Debian:trixie-slim.
- Install Bun via the official script and configure its environment variables.
- Replace apk package commands with apt-get for managing dependencies, including cache cleanup.