### PR TITLE
ci: add native arm64 build

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -23,8 +23,16 @@ env:
 
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
+   build:
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      matrix:
+        platform: [amd64, arm64]
+        include:
+          - platform: amd64
+            runner: ubuntu-24.04
+          - platform: arm64
+            runner: ubuntu-24.04-arm
     permissions:
       contents: read
       packages: write
@@ -71,7 +79,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/${{ matrix.platform }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Summary by Sourcery

Enable native arm64 Docker image builds in CI by introducing a multi-platform build matrix with dedicated runners and dynamic platform configuration

CI:
- Introduce a build matrix for amd64 and arm64 with corresponding ubuntu runners
- Parameterize the Docker build-push action to use the matrix.platform instead of hardcoded platforms