### PR TITLE
Fix account page title

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -495,7 +495,7 @@ const app = new Elysia({
     }
 
     return (
-      <BaseHtml webroot={WEBROOT} title="ConvertX | Login">
+      <BaseHtml webroot={WEBROOT} title="ConvertX | Account">
         <>
           <Header
             webroot={WEBROOT}


### PR DESCRIPTION
The current account page title still has „login“ instead of something fitting in it.