### PR TITLE
Fix EMF to PNG conversion issue #362

### DIFF
--- a/src/converters/imagemagick.ts
+++ b/src/converters/imagemagick.ts
@@ -460,6 +460,13 @@ export function convert(
     }
   }
 
+  // Handle EMF files specifically to avoid LibreOffice delegate issues
+  if (fileType === "emf") {
+    // Use direct conversion without delegates for EMF files
+    inputArgs = ["-define", "emf:delegate=false", "-density", "300"];
+    outputArgs = ["-background", "white", "-alpha", "remove"];
+  }
+
   return new Promise((resolve, reject) => {
     execFile(
       "magick",

--- a/src/converters/imagemagick.ts
+++ b/src/converters/imagemagick.ts
@@ -463,8 +463,8 @@ export function convert(
   // Handle EMF files specifically to avoid LibreOffice delegate issues
   if (fileType === "emf") {
     // Use direct conversion without delegates for EMF files
-    inputArgs = ["-define", "emf:delegate=false", "-density", "300"];
-    outputArgs = ["-background", "white", "-alpha", "remove"];
+    inputArgs.push("-define", "emf:delegate=false", "-density", "300");
+    outputArgs.push("-background", "white", "-alpha", "remove");
   }
 
   return new Promise((resolve, reject) => {

--- a/src/converters/main.ts
+++ b/src/converters/main.ts
@@ -47,6 +47,11 @@ const properties: Record<
     ) => unknown;
   }
 > = {
+  // Prioritize Inkscape for EMF files as it handles them better than ImageMagick
+  inkscape: {
+    properties: propertiesInkscape,
+    converter: convertInkscape,
+  },
   libjxl: {
     properties: propertiesLibjxl,
     converter: convertLibjxl,
@@ -86,10 +91,6 @@ const properties: Record<
   graphicsmagick: {
     properties: propertiesGraphicsmagick,
     converter: convertGraphicsmagick,
-  },
-  inkscape: {
-    properties: propertiesInkscape,
-    converter: convertInkscape,
   },
   assimp: {
     properties: propertiesassimp,


### PR DESCRIPTION
- Add EMF-specific handling in ImageMagick converter to avoid LibreOffice delegate issues
- Disable EMF delegate and set proper conversion parameters (density: 300, background: white, alpha: remove)
- Prioritize Inkscape over ImageMagick for EMF files as it handles them natively
- Resolves LibreOffice delegate command failures when converting EMF files

Fixes #362

## Summary by Sourcery

Improve EMF file conversion by prioritizing Inkscape and customizing ImageMagick parameters to avoid LibreOffice delegate failures

Bug Fixes:
- Add EMF-specific handling in ImageMagick converter to disable LibreOffice delegates and ensure proper density, background, and alpha settings
- Resolve command failures when converting EMF files via LibreOffice delegates

Enhancements:
- Prioritize using Inkscape for EMF files as it provides native handling