### PR TITLE
Fix history for users who have a setup that does not use accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,17 +80,19 @@ If you get unable to open database file run `chown -R $USER:$USER path` on the p
 
 All are optional, JWT_SECRET is recommended to be set.
 
-| Name                      | Default                                            | Description                                                                                                               |
-| ------------------------- | -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
-| JWT_SECRET                | when unset it will use the value from randomUUID() | A long and secret string used to sign the JSON Web Token                                                                  |
-| ACCOUNT_REGISTRATION      | false                                              | Allow users to register accounts                                                                                          |
-| HTTP_ALLOWED              | false                                              | Allow HTTP connections, only set this to true locally                                                                     |
-| ALLOW_UNAUTHENTICATED     | false                                              | Allow unauthenticated users to use the service, only set this to true locally                                             |
-| AUTO_DELETE_EVERY_N_HOURS | 24                                                 | Checks every n hours for files older then n hours and deletes them, set to 0 to disable                                   |
-| WEBROOT                   |                                                    | The address to the root path setting this to "/convert" will serve the website on "example.com/convert/"                  |
-| FFMPEG_ARGS               |                                                    | Arguments to pass to ffmpeg, e.g. `-preset veryfast`                                                                      |
-| HIDE_HISTORY              | false                                              | Hide the history page                                                                                                     |
-| LANGUAGE                  | en                                                 | Language to format date strings in, specified as a [BCP 47 language tag](https://en.wikipedia.org/wiki/IETF_language_tag) |
+| Name                         | Default                                            | Description                                                                                                               |
+| ---------------------------- | -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| JWT_SECRET                   | when unset it will use the value from randomUUID() | A long and secret string used to sign the JSON Web Token                                                                  |
+| ACCOUNT_REGISTRATION         | false                                              | Allow users to register accounts                                                                                          |
+| HTTP_ALLOWED                 | false                                              | Allow HTTP connections, only set this to true locally                                                                     |
+| ALLOW_UNAUTHENTICATED        | false                                              | Allow unauthenticated users to use the service, only set this to true locally                                             |
+| AUTO_DELETE_EVERY_N_HOURS    | 24                                                 | Checks every n hours for files older then n hours and deletes them, set to 0 to disable                                   |
+| WEBROOT                      |                                                    | The address to the root path setting this to "/convert" will serve the website on "example.com/convert/"                  |
+| FFMPEG_ARGS                  |                                                    | Arguments to pass to ffmpeg, e.g. `-preset veryfast`                                                                      |
+| HIDE_HISTORY                 | false                                              | Hide the history page                                                                                                     |
+| LANGUAGE                     | en                                                 | Language to format date strings in, specified as a [BCP 47 language tag](https://en.wikipedia.org/wiki/IETF_language_tag) |
+| UNAUTHENTICATED_USER_SHARING | false                                              | Shares conversion history between all unauthenticated users                                                               |
+
 
 ### Docker images
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -15,5 +15,6 @@ services:
       # - WEBROOT=/convertx # the root path of the web interface, leave empty to disable
       # - HIDE_HISTORY=true # hides the history tab in the web interface, defaults to false
       - TZ=Europe/Stockholm # set your timezone, defaults to UTC
+      # - UNAUTHENTICATED_USER_SHARING=true # for use with ALLOW_UNAUTHENTICATED=true to share history with all unauthenticated users / devices
     ports:
       - 3000:3000

--- a/src/helpers/env.ts
+++ b/src/helpers/env.ts
@@ -17,3 +17,6 @@ export const WEBROOT = process.env.WEBROOT ?? "";
 export const LANGUAGE = process.env.LANGUAGE?.toLowerCase() || "en";
 
 export const MAX_CONVERT_PROCESS = process.env.MAX_CONVERT_PROCESS && Number(process.env.MAX_CONVERT_PROCESS) > 0 ? Number(process.env.MAX_CONVERT_PROCESS) : 0
+
+export const UNAUTHENTICATED_USER_SHARING =
+  process.env.UNAUTHENTICATED_USER_SHARING?.toLowerCase() === "true" || false;

--- a/src/pages/root.tsx
+++ b/src/pages/root.tsx
@@ -33,7 +33,7 @@ export const root = new Elysia()
     let user: ({ id: string } & JWTPayloadSpec) | false = false;
     if (ALLOW_UNAUTHENTICATED) {
       const newUserId = String(
-        randomInt(2 ** 24, Math.min(2 ** 48 + 2 ** 24 - 1, Number.MAX_SAFE_INTEGER)),
+        ACCOUNT_REGISTRATION ? randomInt(2 ** 24, Math.min(2 ** 48 + 2 ** 24 - 1, Number.MAX_SAFE_INTEGER)) : 0,
       );
       const accessToken = await jwt.sign({
         id: newUserId,

--- a/src/pages/root.tsx
+++ b/src/pages/root.tsx
@@ -12,6 +12,7 @@ import {
   ALLOW_UNAUTHENTICATED,
   HIDE_HISTORY,
   HTTP_ALLOWED,
+  UNAUTHENTICATED_USER_SHARING,
   WEBROOT,
 } from "../helpers/env";
 import { FIRST_RUN, userService } from "./user";
@@ -33,7 +34,7 @@ export const root = new Elysia()
     let user: ({ id: string } & JWTPayloadSpec) | false = false;
     if (ALLOW_UNAUTHENTICATED) {
       const newUserId = String(
-        ACCOUNT_REGISTRATION ? randomInt(2 ** 24, Math.min(2 ** 48 + 2 ** 24 - 1, Number.MAX_SAFE_INTEGER)) : 0,
+        UNAUTHENTICATED_USER_SHARING ? 0 : randomInt(2 ** 24, Math.min(2 ** 48 + 2 ** 24 - 1, Number.MAX_SAFE_INTEGER)),
       );
       const accessToken = await jwt.sign({
         id: newUserId,


### PR DESCRIPTION
Solves: #358

This PR changes how account IDs are handled for users who have the `ALLOW_UNAUTHENTICATED=true` and `ACCOUNT_REGISTRATION=false` enviornment variables set.
When account registration is disabled and the server allows for unauthenticated users, the server now assumes that there will be only 1 account and set the user ID to 0 for all users. This fixes an issue where history could not be shared across devices when creating accounts was not present.

(PS: I am a new dev so apologies for not using some best practices, I am very open to feedback and fixing the patch if you find any issues with it!)

## Summary by Sourcery

Bug Fixes:
- Use a fixed user ID (0) for all unauthenticated users when account registration is disabled to enable history sharing across devices