### PR TITLE
chore: hardcode ghcr token

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -12,6 +12,7 @@ on:
 env:
   IMAGE_NAME: ${{ github.repository }}
   DOCKERHUB_USERNAME: c4illin
+  GHCR_USERNAME: c4illin
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -72,8 +73,8 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ env.GHCR_USERNAME }}
+          password: ${{ secrets.GHCR_TOKEN }}
 
       - name: Build and push by digest
         id: build
@@ -141,8 +142,8 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ env.GHCR_USERNAME }}
+          password: ${{ secrets.GHCR_TOKEN }}
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3


### PR DESCRIPTION
## Summary by Sourcery

Update docker-publish GitHub Actions workflow to authenticate to GitHub Container Registry using dedicated credentials

CI:
- Add GHCR_USERNAME environment variable
- Replace github.actor and GITHUB_TOKEN with GHCR_USERNAME and GHCR_TOKEN for ghcr.io login in both jobs