### PR TITLE
chore: test without push

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -84,7 +84,8 @@ jobs:
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
           annotations: ${{ steps.meta.outputs.annotations }}
-          outputs: type=image,name=ghcr.io/${{ env.REPO }},push-by-digest=true,name-canonical=true,push=true,oci-mediatypes=true
+          outputs: type=image,name=ghcr.io/${{ env.REPO }},push-by-digest=true,name-canonical=true,push=false,oci-mediatypes=true
+          push: false
           cache-from: type=gha,scope=${{ matrix.platform }}
           cache-to: type=gha,mode=max,scope=${{ matrix.platform }}
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -84,8 +84,8 @@ jobs:
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
           annotations: ${{ steps.meta.outputs.annotations }}
-          outputs: type=image,name=ghcr.io/${{ env.REPO }},push-by-digest=true,name-canonical=true,push=false,oci-mediatypes=true
-          push: false
+          outputs: type=image,name=ghcr.io/${{ env.REPO }},push-by-digest=true,name-canonical=true,oci-mediatypes=true
+          push: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
           cache-from: type=gha,scope=${{ matrix.platform }}
           cache-to: type=gha,mode=max,scope=${{ matrix.platform }}
 
@@ -104,6 +104,7 @@ jobs:
           retention-days: 1
 
   merge:
+    if: github.event.pull_request.head.repo.full_name == github.repository
     name: Merge Docker manifests
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## Summary by Sourcery

Disable Docker image push in the GitHub Actions docker-publish workflow for testing purposes

CI:
- Set build-push action's push flag to false in the docker-publish workflow
- Add explicit push: false key to the docker-publish job configuration