### PR TITLE
Feat: add VTracer converter for raster to vector conversion

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -82,14 +82,11 @@ RUN ARCH=$(uname -m) && \
   else \
     VTRACER_ASSET="vtracer-x86_64-unknown-linux-musl.tar.gz"; \
   fi && \
-  echo "Downloading VTracer: $VTRACER_ASSET" && \
   curl -L -o /tmp/vtracer.tar.gz "https://github.com/visioncortex/vtracer/releases/download/0.6.4/${VTRACER_ASSET}" && \
   tar -xzf /tmp/vtracer.tar.gz -C /tmp/ && \
   mv /tmp/vtracer /usr/local/bin/vtracer && \
   chmod +x /usr/local/bin/vtracer && \
-  rm /tmp/vtracer.tar.gz && \
-  echo "VTracer installed successfully" && \
-  vtracer --help
+  rm /tmp/vtracer.tar.gz
 
 COPY --from=install /temp/prod/node_modules node_modules
 COPY --from=prerelease /app/public/generated.css /app/public/

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,7 +75,7 @@ RUN apt-get update && apt-get install -y \
   --no-install-recommends \
   && rm -rf /var/lib/apt/lists/*
 
-# Install VTracer binary (corrected version using tar.gz)
+# Install VTracer binary
 RUN ARCH=$(uname -m) && \
   if [ "$ARCH" = "aarch64" ]; then \
     VTRACER_ASSET="vtracer-aarch64-unknown-linux-musl.tar.gz"; \
@@ -95,10 +95,11 @@ COPY --from=install /temp/prod/node_modules node_modules
 COPY --from=prerelease /app/public/generated.css /app/public/
 COPY --from=prerelease /app/dist /app/dist
 
+# COPY . .
 RUN mkdir data
 
 EXPOSE 3000/tcp
+# used for calibre
 ENV QTWEBENGINE_CHROMIUM_FLAGS="--no-sandbox"
 ENV NODE_ENV=production
 ENTRYPOINT [ "bun", "run", "dist/src/index.js" ]
-

--- a/README.md
+++ b/README.md
@@ -25,22 +25,23 @@ A self-hosted online file converter. Supports over a thousand different formats.
 
 ## Converters supported
 
-| Converter                                        | Use case         | Converts from | Converts to |
-| ------------------------------------------------ | ---------------- | ------------- | ----------- |
-| [libjxl](https://github.com/libjxl/libjxl)       | JPEG XL          | 11            | 11          |
-| [resvg](https://github.com/RazrFalcon/resvg)     | SVG              | 1             | 1           |
-| [Vips](https://github.com/libvips/libvips)       | Images           | 45            | 23          |
-| [libheif](https://github.com/strukturag/libheif) | HEIF             | 2             | 4           |
-| [XeLaTeX](https://tug.org/xetex/)                | LaTeX            | 1             | 1           |
-| [Calibre](https://calibre-ebook.com/)            | E-books          | 26            | 19          |
-| [Pandoc](https://pandoc.org/)                    | Documents        | 43            | 65          |
-| [dvisvgm](https://dvisvgm.de/)                   | Vector images    | 4             | 2           |
-| [ImageMagick](https://imagemagick.org/)          | Images           | 245           | 183         |
-| [GraphicsMagick](http://www.graphicsmagick.org/) | Images           | 167           | 130         |
-| [Inkscape](https://inkscape.org/)                | Vector images    | 7             | 17          |
-| [Assimp](https://github.com/assimp/assimp)       | 3D Assets        | 77            | 23          |
-| [FFmpeg](https://ffmpeg.org/)                    | Video            | ~472          | ~199        |
-| [Potrace](https://potrace.sourceforge.net/)      | Raster to vector | 4             | 11          |
+| Converter                                          | Use case         | Converts from | Converts to |
+| -------------------------------------------------- | ---------------- | ------------- | ----------- |
+| [libjxl](https://github.com/libjxl/libjxl)         | JPEG XL          | 11            | 11          |
+| [resvg](https://github.com/RazrFalcon/resvg)       | SVG              | 1             | 1           |
+| [Vips](https://github.com/libvips/libvips)         | Images           | 45            | 23          |
+| [libheif](https://github.com/strukturag/libheif)   | HEIF             | 2             | 4           |
+| [XeLaTeX](https://tug.org/xetex/)                  | LaTeX            | 1             | 1           |
+| [Calibre](https://calibre-ebook.com/)              | E-books          | 26            | 19          |
+| [Pandoc](https://pandoc.org/)                      | Documents        | 43            | 65          |
+| [dvisvgm](https://dvisvgm.de/)                     | Vector images    | 4             | 2           |
+| [ImageMagick](https://imagemagick.org/)            | Images           | 245           | 183         |
+| [GraphicsMagick](http://www.graphicsmagick.org/)   | Images           | 167           | 130         |
+| [Inkscape](https://inkscape.org/)                  | Vector images    | 7             | 17          |
+| [Assimp](https://github.com/assimp/assimp)         | 3D Assets        | 77            | 23          |
+| [FFmpeg](https://ffmpeg.org/)                      | Video            | ~472          | ~199        |
+| [Potrace](https://potrace.sourceforge.net/)        | Raster to vector | 4             | 11          |
+| [VTracer](https://github.com/visioncortex/vtracer) | Raster to vector | 8             | 1           |
 
 <!-- many ffmpeg fileformats are duplicates -->
 

--- a/src/converters/main.ts
+++ b/src/converters/main.ts
@@ -20,9 +20,8 @@ import { convert as convertPandoc, properties as propertiesPandoc } from "./pand
 import { convert as convertPotrace, properties as propertiesPotrace } from "./potrace";
 import { convert as convertresvg, properties as propertiesresvg } from "./resvg";
 import { convert as convertImage, properties as propertiesImage } from "./vips";
+import { convert as convertVtracer, properties as propertiesVtracer } from "./vtracer";
 import { convert as convertxelatex, properties as propertiesxelatex } from "./xelatex";
-import {convert as convertVtracer, properties as propertiesVtracer} from './vtracer';
-
 
 // This should probably be reconstructed so that the functions are not imported instead the functions hook into this to make the converters more modular
 
@@ -122,7 +121,7 @@ const properties: Record<
   vtracer: {
     properties: propertiesVtracer,
     converter: convertVtracer,
-  }
+  },
 };
 
 function chunks<T>(arr: T[], size: number): T[][] {

--- a/src/converters/main.ts
+++ b/src/converters/main.ts
@@ -21,6 +21,8 @@ import { convert as convertPotrace, properties as propertiesPotrace } from "./po
 import { convert as convertresvg, properties as propertiesresvg } from "./resvg";
 import { convert as convertImage, properties as propertiesImage } from "./vips";
 import { convert as convertxelatex, properties as propertiesxelatex } from "./xelatex";
+import {convert as convertVtracer, properties as propertiesVtracer} from './vtracer';
+
 
 // This should probably be reconstructed so that the functions are not imported instead the functions hook into this to make the converters more modular
 
@@ -117,6 +119,10 @@ const properties: Record<
     properties: propertiesPotrace,
     converter: convertPotrace,
   },
+  vtracer: {
+    properties: propertiesVtracer,
+    converter: convertVtracer,
+  }
 };
 
 function chunks<T>(arr: T[], size: number): T[][] {

--- a/src/converters/vtracer.ts
+++ b/src/converters/vtracer.ts
@@ -72,7 +72,7 @@ export function convert(
 
       execFile("vtracer", args, (error, stdout, stderr) => {
         if (error) {
-          reject(`error: ${error}`);
+          reject(`error: ${error}${stderr ? `\nstderr: ${stderr}` : ''}`);
           return;
         }
 

--- a/src/converters/vtracer.ts
+++ b/src/converters/vtracer.ts
@@ -10,6 +10,20 @@ export const properties = {
   },
 };
 
+interface VTracerOptions {
+  colormode?: string;
+  hierarchical?: string;
+  mode?: string;
+  filter_speckle?: string | number;
+  color_precision?: string | number;
+  layer_difference?: string | number;
+  corner_threshold?: string | number;
+  length_threshold?: string | number;
+  max_iterations?: string | number;
+  splice_threshold?: string | number;
+  path_precision?: string | number;
+}
+
 export function convert(
   filePath: string,
   fileType: string,
@@ -24,34 +38,40 @@ export function convert(
 
     // Add optional parameter if provided
     if (options && typeof options === "object") {
-      const opts = options as Record<string, any>;
-
-      const validOptions = [
-        "colormode", "hierarchical", "mode", "filter_speckle",
-        "color_precision", "layer_difference", "corner_threshold",
-        "length_threshold", "max_iterations", "splice_threshold",
+      const opts = options as VTracerOptions;
+      const validOptions: Array<keyof VTracerOptions> = [
+        "colormode",
+        "hierarchical",
+        "mode",
+        "filter_speckle",
+        "color_precision",
+        "layer_difference",
+        "corner_threshold",
+        "length_threshold",
+        "max_iterations",
+        "splice_threshold",
         "path_precision",
       ];
 
       for (const option of validOptions) {
-          if(opts[option]){
-            args.push(`--${option}`, opts[option]);
-          }
+        if (opts[option] !== undefined) {
+          args.push(`--${option}`, String(opts[option]));
+        }
       }
     }
 
     execFile("vtracer", args, (error, stdout, stderr) => {
-      if(error){
-        reject(`error: ${error}${stderr ? `\nstderr: ${stderr}` : ''}`)
+      if (error) {
+        reject(`error: ${error}${stderr ? `\nstderr: ${stderr}` : ""}`);
         return;
       }
 
-      if(stdout){
-        console.log(`stdout: ${stdout}`)
+      if (stdout) {
+        console.log(`stdout: ${stdout}`);
       }
 
-      if(stderr){
-        console.log(`stderr: ${stderr}`)
+      if (stderr) {
+        console.log(`stderr: ${stderr}`);
       }
 
       resolve("Done");

--- a/src/converters/vtracer.ts
+++ b/src/converters/vtracer.ts
@@ -22,70 +22,39 @@ export function convert(
     // Build vtracer arguments
     const args = ["--input", filePath, "--output", targetPath];
 
-    // Add option parameter if provided
+    // Add optional parameter if provided
     if (options && typeof options === "object") {
       const opts = options as Record<string, any>;
 
-      if (opts.colormode) {
-        args.push("--colormode", opts.colormode);
+      const validOptions = [
+        "colormode", "hierarchical", "mode", "filter_speckle",
+        "color_precision", "layer_difference", "corner_threshold",
+        "length_threshold", "max_iterations", "splice_threshold",
+        "path_precision",
+      ];
+
+      for (const option of validOptions) {
+          if(opts[option]){
+            args.push(`--${option}`, opts[option]);
+          }
       }
-
-      if (opts.hierarchical) {
-        args.push("--hierarchical", opts.hierarchical);
-      }
-
-      if (opts.mode) {
-        args.push("--mode", opts.mode);
-      }
-
-      if (opts.filter_speckle) {
-        args.push("--filter_speckle", opts.filter_speckle);
-      }
-
-      if (opts.color_precision) {
-        args.push("--color_precision", opts.color_precision);
-      }
-
-      if (opts.layer_difference) {
-        args.push("--layer_difference", opts.layer_difference);
-      }
-
-      if (opts.corner_threshold) {
-        args.push("--corner_threshold", opts.corner_threshold);
-      }
-
-      if (opts.length_threshold) {
-        args.push("--length_threshold", opts.length_threshold);
-      }
-
-      if (opts.max_iterations) {
-        args.push("--max_iterations", opts.max_iterations);
-      }
-
-      if (opts.splice_threshold) {
-        args.push("--splice_threshold", opts.splice_threshold);
-      }
-
-      if (opts.path_precision) {
-        args.push("--path_precision", opts.path_precision);
-      }
-
-      execFile("vtracer", args, (error, stdout, stderr) => {
-        if (error) {
-          reject(`error: ${error}${stderr ? `\nstderr: ${stderr}` : ''}`);
-          return;
-        }
-
-        if (stdout) {
-          console.log(`stdout: ${stdout}`);
-        }
-
-        if (stderr) {
-          console.log(`stderr: ${stderr}`);
-        }
-
-        resolve("Done");
-      });
     }
+
+    execFile("vtracer", args, (error, stdout, stderr) => {
+      if(error){
+        reject(`error: ${error}${stderr ? `\nstderr: ${stderr}` : ''}`)
+        return;
+      }
+
+      if(stdout){
+        console.log(`stdout: ${stdout}`)
+      }
+
+      if(stderr){
+        console.log(`stderr: ${stderr}`)
+      }
+
+      resolve("Done");
+    });
   });
 }

--- a/src/converters/vtracer.ts
+++ b/src/converters/vtracer.ts
@@ -1,0 +1,91 @@
+import { execFile as execFileOriginal } from "node:child_process";
+import { ExecFileFn } from "./types";
+
+export const properties = {
+  from: {
+    images: ["jpg", "jpeg", "png", "bmp", "gif", "tiff", "tif", "webp"],
+  },
+  to: {
+    images: ["svg"],
+  },
+};
+
+export function convert(
+  filePath: string,
+  fileType: string,
+  convertTo: string,
+  targetPath: string,
+  options?: unknown,
+  execFile: ExecFileFn = execFileOriginal, // to make it mockable
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    // Build vtracer arguments
+    const args = ["--input", filePath, "--output", targetPath];
+
+    // Add option parameter if provided
+    if (options && typeof options === "object") {
+      const opts = options as Record<string, any>;
+
+      if (opts.colormode) {
+        args.push("--colormode", opts.colormode);
+      }
+
+      if (opts.hierarchical) {
+        args.push("--hierarchical", opts.hierarchical);
+      }
+
+      if (opts.mode) {
+        args.push("--mode", opts.mode);
+      }
+
+      if (opts.filter_speckle) {
+        args.push("--filter_speckle", opts.filter_speckle);
+      }
+
+      if (opts.color_precision) {
+        args.push("--color_precision", opts.color_precision);
+      }
+
+      if (opts.layer_difference) {
+        args.push("--layer_difference", opts.layer_difference);
+      }
+
+      if (opts.corner_threshold) {
+        args.push("--corner_threshold", opts.corner_threshold);
+      }
+
+      if (opts.length_threshold) {
+        args.push("--length_threshold", opts.length_threshold);
+      }
+
+      if (opts.max_iterations) {
+        args.push("--max_iterations", opts.max_iterations);
+      }
+
+      if (opts.splice_threshold) {
+        args.push("--splice_threshold", opts.splice_threshold);
+      }
+
+      if (opts.path_precision) {
+        args.push("--path_precision", opts.path_precision);
+      }
+
+      execFile("vtracer", args, (error, stdout, stderr) => {
+        if (error) {
+          reject(`error: ${error}`);
+          return;
+        }
+
+        if (stdout) {
+          console.log(`stdout: ${stdout}`);
+        }
+
+        if (stderr) {
+          console.log(`stderr: ${stderr}`);
+        }
+
+        resolve("Done");
+      });
+    }
+  });
+}


### PR DESCRIPTION
This PR adds VTracer support to ConvertX, enabling high-quality raster-to-vector image conversion.

###  What's Changed

####  New Converter Implementation
- ✅ Added `src/converters/vtracer.ts` with full VTracer integration
- ✅ Supports **8 input formats**: PNG, JPG, JPEG, BMP, GIF, TIFF, TIF, WebP → **SVG**

####  Docker Integration  
- ✅ Updated Dockerfile to install VTracer v0.6.4 binary during build
- ✅ Multi-architecture support (x86_64 and aarch64)

####  Documentation
- ✅ Updated README.md converter table with VTracer entry
- ✅ Maintains consistent documentation style


**Quality Assurance:**
- No breaking changes to existing functionality
- Maintains backward compatibility
- Docker image builds successfully with VTracer included
---

## Summary by Sourcery

Add VTracer-based raster-to-vector conversion support by introducing a new converter, integrating its binary into the Docker build, and updating documentation accordingly.

New Features:
- Add VTracer converter supporting eight raster formats (PNG, JPG, JPEG, BMP, GIF, TIFF, TIF, WebP) to SVG and register it in the converter registry

Build:
- Update Dockerfile to download and install VTracer v0.6.4 binary with x86_64 and aarch64 support

Documentation:
- Update README to include VTracer in the supported converters table