### PR TITLE
Adding latexmk to dockerfile install packages, convertx errors otherw…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,7 @@ RUN apt-get update && apt-get install -y \
   graphicsmagick \
   imagemagick-7.q16 \
   inkscape \
+  latexmk \
   libheif-examples \
   libjxl-tools \
   libreoffice \


### PR DESCRIPTION
Was getting complaints from xetex about latexmk not being in path, installing latexmk via apt in container solved the issue. Adding latexmk to apps to install in Dockerfile