### PR TITLE
fix: workaround for #435

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -22,6 +22,9 @@ import { healthcheck } from "./pages/healthcheck";
 export const uploadsDir = "./data/uploads/";
 export const outputDir = "./data/output/";
 
+// Fix for Elysia issue with Bun, (see https://github.com/oven-sh/bun/issues/12161)
+process.getBuiltinModule = require;
+
 const app = new Elysia({
   serve: {
     maxRequestBodySize: Number.MAX_SAFE_INTEGER,


### PR DESCRIPTION
@Rdeisenroth ported your fix in the meantime

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a runtime workaround for Elysia on Bun by setting process.getBuiltinModule = require. This prevents startup crashes and restores the server, addressing #435 while Bun bug 12161 is unresolved.

<sup>Written for commit 91aa2c144dfef204f66781d90c70f3b176a082d7. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

