### PR TITLE
fix: Version wasn't bumped for v0.16.0

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,0 +1,26 @@
+name: Bump Version
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+
+jobs:
+  bump-version:
+    name: Bump Version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
+      - name: Bump version and push tag
+        uses: ramonpaolo/bump-version@v2.3.1
+        with:
+          tag: ${{ github.ref_name }}
+          commit: true
+          branch_to_push: "main"


### PR DESCRIPTION
Fixes #455

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a GitHub Actions workflow to automatically bump the version when a release tag (vX.Y.Z) is pushed. Commits the bump to main to prevent missed versions like v0.16.0 (addresses #455).

<sup>Written for commit 4ca5d33f4047f64fd6b5101e1293098e74188102. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

