### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/run-bun-test.yml
+++ b/.github/workflows/run-bun-test.yml
@@ -1,4 +1,6 @@
 name: Check Tests
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/C4illin/ConvertX/security/code-scanning/5](https://github.com/C4illin/ConvertX/security/code-scanning/5)

To address this issue, add the `permissions` key to the workflow YAML to explicitly limit the permissions of the `GITHUB_TOKEN`. The safest minimal permission for the provided workflow, which only checks out code and runs tests, is `contents: read`. This key can be placed either at the root of the workflow file (so it applies to all jobs) or under the specific job (`test:`). GitHub’s recommended approach is to add it at the root level unless jobs require distinct permissions.

Specifically, insert the following just after the workflow `name` and before the `on:` key at the top of `.github/workflows/run-bun-test.yml`:

```yaml
permissions:
  contents: read
```

This restricts the generated `GITHUB_TOKEN` to read-only access to repository contents, which is suitable for CI tasks like these.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set GITHUB_TOKEN permissions to contents: read at the root of .github/workflows/run-bun-test.yml. Addresses code scanning alert #5 by restricting the workflow’s repository access to read-only.

<sup>Written for commit 0f971c52b2378279cdd5e73fd6081ce7d0210eed. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

