### PR TITLE
Potential fix for code scanning alert no. 6: Unnecessary use of `cat` process

### DIFF
--- a/src/helpers/printVersions.ts
+++ b/src/helpers/printVersions.ts
@@ -1,10 +1,11 @@
 import { exec } from "node:child_process";
+import { readFile } from "node:fs";
 import { version } from "../../package.json";
 
 console.log(`ConvertX v${version}`);
 
 if (process.env.NODE_ENV === "production") {
-  exec("cat /etc/os-release", (error, stdout) => {
+  readFile("/etc/os-release", "utf8", (error, stdout) => {
     if (error) {
       console.error("Not running on docker, this is not supported.");
     }


### PR DESCRIPTION
Potential fix for [https://github.com/C4illin/ConvertX/security/code-scanning/6](https://github.com/C4illin/ConvertX/security/code-scanning/6)

The problem is the use of `exec("cat /etc/os-release", callback)` on line 7, which unnecessarily spawns a shell process to read a file.  
The correct fix is to replace this with `fs.readFile("/etc/os-release", "utf8", callback)`, which reads the file asynchronously using Node's standard library, improving efficiency and portability (and removing the need to spawn a shell command).

**Details:**
- Import the Node.js `fs` module at the top of the file: `import { readFile } from "node:fs";`
- Replace the `exec("cat /etc/os-release", ...)` call with `readFile("/etc/os-release", "utf8", ...)`. This ensures `stdout` in the function becomes the file content as expected.
- The callback can remain unchanged, as the second parameter continues to be the file contents.

All other lines in this file remain unchanged.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace shell-based file read with Node’s fs.readFile to fix code scanning alert #6. This removes the unnecessary cat process, improves efficiency and portability, and keeps the callback behavior unchanged.

<sup>Written for commit c3bb5d646d19eda6b16ea6945c6bc769413009ba. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

