### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/conventional-label.yml
+++ b/.github/workflows/conventional-label.yml
@@ -2,6 +2,9 @@ on:
   pull_request_target:
     types: [opened, edited]
 name: conventional-release-labels
+permissions:
+  contents: read
+  pull-requests: write
 jobs:
   label:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/C4illin/ConvertX/security/code-scanning/1](https://github.com/C4illin/ConvertX/security/code-scanning/1)

To fix the problem, add a `permissions` block to the job or at the root of the workflow. Since this workflow uses an action that applies labels to pull requests, it needs write permission to the `pull-requests` scope but does not need broader write access (such as to code/content). Therefore, set `pull-requests: write` and set all other typical permissions to their lowest sensible values, usually `contents: read`. Add this `permissions` block at the job level (under `jobs: label:`) or at the workflow root; putting it at the root will apply to all jobs and makes the intention clearer for future changes.

Change the file `.github/workflows/conventional-label.yml` as follows:
- Insert, after the `name:` line (line 4), a block:
    ```yaml
    permissions:
      contents: read
      pull-requests: write
    ```
This restricts the token for all jobs in this workflow to the minimum needed for labeling pull requests but no more.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add explicit permissions to the conventional-label workflow to resolve the “workflow does not contain permissions” alert and enforce least-privilege access. Sets contents: read and pull-requests: write at the workflow root so labeling works without broader write.

<sup>Written for commit 83f85b14dd15fb0168906c52c8bfcda8862d4a74. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

