### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check-lint.yml
+++ b/.github/workflows/check-lint.yml
@@ -1,4 +1,6 @@
 name: Check Lint
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/C4illin/ConvertX/security/code-scanning/3](https://github.com/C4illin/ConvertX/security/code-scanning/3)

To fix this problem, an explicit `permissions` block should be added to the workflow to restrict the default access of the GITHUB_TOKEN. Since this workflow only checks out repository contents and runs local linting commands, only `contents: read` permission is needed—the minimum required for reading repository code. The best way is to add a `permissions:` block at the root/top level, immediately after the workflow name (line 1), so that it applies to all jobs unless a job-specific block overrides it. No other changes or imports are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an explicit permissions block to .github/workflows/check-lint.yml to restrict GITHUB_TOKEN to contents: read. This enforces least privilege for the lint workflow and addresses code scanning alert #3.

<sup>Written for commit f7c18bb871b5b57c7dd80dc55b46bf2e96f0b7c2. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

