### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,4 +1,6 @@
 name: Bump Version
+permissions:
+  contents: write
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/C4illin/ConvertX/security/code-scanning/2](https://github.com/C4illin/ConvertX/security/code-scanning/2)

To fix the issue, add an explicit `permissions` block to the workflow file. The permissions block can be at the workflow root level (applies to all jobs), or at the job level (just for `bump-version`). The minimal starting point is usually recommended to be `contents: read`, but since this workflow likely pushes commits/tags (see the step using `ramonpaolo/bump-version` and the `commit: true` and `branch_to_push` inputs), it will require `contents: write`. Thus, the best way to fix is to add:

```yaml
permissions:
  contents: write
```

at the top level of the YAML file, after the `name:` (or before/after `on:`), or under the bump-version job.

Since this workflow appears to operate only on tags and pushes a commit back, `contents: write` is the least privilege required for this workflow to function. 

Change:  
- Add the following block after `name: Bump Version` (line 1), before `on:`:
  ```yaml
  permissions:
    contents: write
  ```

No additional imports or dependencies are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add explicit permissions to the bump-version GitHub Actions workflow to resolve the code scanning alert. Sets contents: write so the job can push commits/tags with least privilege.

- **Bug Fixes**
  - Added a workflow-level permissions block: contents: write.

<sup>Written for commit 4fba19b435d8bb96f28150246f166d932c5c97dc. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

