### PR TITLE
add .wma file as ffmpeg input

### DIFF
--- a/src/converters/ffmpeg.ts
+++ b/src/converters/ffmpeg.ts
@@ -456,6 +456,7 @@ export const properties = {
       "webm",
       "webp",
       "webvtt",
+      "wma",
       "wow",
       "wsaud",
       "wsd",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added .wma to the FFmpeg input formats so the converter accepts Windows Media Audio files. This enables importing WMA for transcoding without errors.

<sup>Written for commit 3268ac36bd0f5b38e650421dd6243efed3fd7230. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

