### PR TITLE
feat(calibre): add cbz output format support

### DIFF
--- a/src/converters/calibre.ts
+++ b/src/converters/calibre.ts
@@ -35,6 +35,7 @@ export const properties = {
   to: {
     document: [
       "azw3",
+      "cbz",
       "docx",
       "epub",
       "fb2",


### PR DESCRIPTION
Closes #492 



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added CBZ as a supported output format in the Calibre converter. This enables PDF-to-CBZ and other document-to-CBZ exports alongside existing formats.

<sup>Written for commit 544cd0a77957bc9940df73a0c97cee9564508d6e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

