### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dockerhub-description.yml
+++ b/.github/workflows/dockerhub-description.yml
@@ -1,4 +1,6 @@
 name: Update Docker Hub Description
+permissions:
+  contents: read
 
 env:
   IMAGE_NAME: ${{ github.repository }}


### PR DESCRIPTION
Potential fix for [https://github.com/C4illin/ConvertX/security/code-scanning/4](https://github.com/C4illin/ConvertX/security/code-scanning/4)

To fix this problem, add an explicit `permissions` block to restrict the default permissions of the workflow's `GITHUB_TOKEN` to the minimum necessary. In this case, since the following actions only require read access to repository contents (checking out the code and updating an external service), `permissions: contents: read` is sufficient. The best place is usually at the root (top-level of the workflow), immediately after the `name:` or before the `env:` block. This will enforce least-privilege access for the whole workflow and its jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Locks down the Docker Hub description workflow by adding permissions: contents: read to the GITHUB_TOKEN, resolving Code Scanning alert #4 and enforcing least privilege without changing behavior.

<sup>Written for commit f48d1aaad179207a57b4bba37e8d53b2f03ef6a7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

