### PR TITLE
fix: allow dynamic server port via environment variable

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -65,7 +65,7 @@ if (process.env.NODE_ENV !== "production") {
   });
 }
 
-app.listen(3000);
+app.listen(process.env.PORT || 3000);
 
 console.log(`🦊 Elysia is running at http://${app.server?.hostname}:${app.server?.port}${WEBROOT}`);
 


### PR DESCRIPTION
Replaced hardcoded port 3000 with process.env.PORT in src/index.tsx to support custom deployment environments.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Server now reads the port from process.env.PORT, falling back to 3000. This enables deployments on platforms that assign dynamic ports.

<sup>Written for commit b08bcca847fe32df2b19caac2768ef7ef441e659. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

