### PR TITLE
security: fix path traversal vulnerability in conversion API

### DIFF
--- a/src/converters/main.ts
+++ b/src/converters/main.ts
@@ -164,13 +164,15 @@ export async function handleConvert(
     const toProcess: Promise<string>[] = [];
     for (const fileName of chunk) {
       const filePath = `${userUploadsDir}${fileName}`;
-      const fileTypeOrig = fileName.split(".").pop() ?? "";
+      const fileTypeOrig = fileName.includes(".") ? (fileName.split(".").pop() ?? "") : "";
       const fileType = normalizeFiletype(fileTypeOrig);
       const newFileExt = normalizeOutputFiletype(convertTo);
-      const newFileName = fileName.replace(
-        new RegExp(`${fileTypeOrig}(?!.*${fileTypeOrig})`),
-        newFileExt,
-      );
+      let newFileName: string;
+      if (fileTypeOrig === "") {
+        newFileName = `${fileName}.${newFileExt}`;
+      } else {
+        newFileName = fileName.replace(new RegExp(`${fileTypeOrig}(?!.*${fileTypeOrig})`), newFileExt);
+      }
       const targetPath = `${userOutputDir}${newFileName}`;
       toProcess.push(
         new Promise((resolve, reject) => {

--- a/src/converters/main.ts
+++ b/src/converters/main.ts
@@ -171,7 +171,10 @@ export async function handleConvert(
       if (fileTypeOrig === "") {
         newFileName = `${fileName}.${newFileExt}`;
       } else {
-        newFileName = fileName.replace(new RegExp(`${fileTypeOrig}(?!.*${fileTypeOrig})`), newFileExt);
+        newFileName = fileName.replace(
+          new RegExp(`${fileTypeOrig}(?!.*${fileTypeOrig})`),
+          newFileExt,
+        );
       }
       const targetPath = `${userOutputDir}${newFileName}`;
       toProcess.push(

--- a/src/pages/convert.tsx
+++ b/src/pages/convert.tsx
@@ -47,7 +47,7 @@ export const convert = new Elysia().use(userService).post(
     const convertTo = normalizeFiletype(body.convert_to.split(",")[0] ?? "");
     const converterName = body.convert_to.split(",")[1];
 
-    if (!converterName) {
+    if (!converterName || convertTo.includes("/") || convertTo.includes("\\") || convertTo.includes("..")) {
       return redirect(`${WEBROOT}/`, 302);
     }
 

--- a/src/pages/convert.tsx
+++ b/src/pages/convert.tsx
@@ -47,7 +47,12 @@ export const convert = new Elysia().use(userService).post(
     const convertTo = normalizeFiletype(body.convert_to.split(",")[0] ?? "");
     const converterName = body.convert_to.split(",")[1];
 
-    if (!converterName || convertTo.includes("/") || convertTo.includes("\\") || convertTo.includes("..")) {
+    if (
+      !converterName ||
+      convertTo.includes("/") ||
+      convertTo.includes("\\") ||
+      convertTo.includes("..")
+    ) {
       return redirect(`${WEBROOT}/`, 302);
     }
 


### PR DESCRIPTION
### 1. Input Validation in `src/pages/convert.tsx`
Added a check to ensure the `convertTo` parameter does not contain path traversal characters (`/`, `\`, `..`). This is the first line of defense, blocking malicious input as soon as it enters the system.

### 2. Robust Filename Construction in `src/converters/main.ts`
The original logic used a regex that would match the end of the string if the original file had no extension, allowing the malicious `convertTo` string to be appended. I've updated this to handle files without extensions explicitly and safely.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Blocks path traversal in the conversion API by validating `convert_to` and building safe output names. Prevents writes outside the output dir; also minor lint cleanup.

- **Bug Fixes**
  - Reject `convert_to` values containing "/", "\" or ".."; still require `converterName`.
  - Handle files without extensions and only replace the final extension when creating the new filename.

<sup>Written for commit 3ec910d177a9dd2bdfbba30bc491a4dc9a2ecd8f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

