### PR TITLE
feat: update to debian testing (forky)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:trixie-slim AS base
+FROM debian:testing-slim AS base
 LABEL org.opencontainers.image.source="https://github.com/C4illin/ConvertX"
 WORKDIR /app
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch Docker base image from debian:trixie-slim to debian:testing-slim to track Debian testing (Forky) and access newer packages. This may change package versions during builds.

<sup>Written for commit b09b33020b728eb83bd2bade66e063b46b6faa20. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

