### PR TITLE
fix(assimp): pass -f<format> so non-extension targets work

### DIFF
--- a/src/converters/assimp.ts
+++ b/src/converters/assimp.ts
@@ -121,20 +121,24 @@ export async function convert(
   execFile: ExecFileFn = execFileOriginal, // to make it mockable
 ): Promise<string> {
   return new Promise((resolve, reject) => {
-    execFile("assimp", ["export", filePath, targetPath, `-f${convertTo}`], (error, stdout, stderr) => {
-      if (error) {
-        reject(`error: ${error}`);
-      }
+    execFile(
+      "assimp",
+      ["export", filePath, targetPath, `-f${convertTo}`],
+      (error, stdout, stderr) => {
+        if (error) {
+          reject(`error: ${error}`);
+        }
 
-      if (stdout) {
-        console.log(`stdout: ${stdout}`);
-      }
+        if (stdout) {
+          console.log(`stdout: ${stdout}`);
+        }
 
-      if (stderr) {
-        console.error(`stderr: ${stderr}`);
-      }
+        if (stderr) {
+          console.error(`stderr: ${stderr}`);
+        }
 
-      resolve("Done");
-    });
+        resolve("Done");
+      },
+    );
   });
 }

--- a/src/converters/assimp.ts
+++ b/src/converters/assimp.ts
@@ -121,7 +121,7 @@ export async function convert(
   execFile: ExecFileFn = execFileOriginal, // to make it mockable
 ): Promise<string> {
   return new Promise((resolve, reject) => {
-    execFile("assimp", ["export", filePath, targetPath], (error, stdout, stderr) => {
+    execFile("assimp", ["export", filePath, targetPath, `-f${convertTo}`], (error, stdout, stderr) => {
       if (error) {
         reject(`error: ${error}`);
       }

--- a/src/helpers/normalizeFiletype.ts
+++ b/src/helpers/normalizeFiletype.ts
@@ -31,6 +31,24 @@ export const normalizeOutputFiletype = (filetype: string): string => {
     case "markdown_mmd":
     case "markdown":
       return "md";
+    // assimp format ids that aren't real file extensions — map to the
+    // canonical extension for the underlying format so the output file
+    // opens in third-party viewers. The format id is still passed to
+    // `assimp export -f<id>` so the right encoding/variant is produced.
+    case "glb2":
+      return "glb";
+    case "gltf2":
+      return "gltf";
+    case "objnomtl":
+      return "obj";
+    case "stlb":
+      return "stl";
+    case "plyb":
+      return "ply";
+    case "fbxa":
+      return "fbx";
+    case "assjson":
+      return "json";
     default:
       return lowercaseFiletype;
   }


### PR DESCRIPTION
My ConvertX on my HomeServer failed to convert an STL file I found into a GLB file using the GLB2 format in `assimp`.

[tools/assimp_cmd/Export.cpp:54](https://github.com/assimp/assimp/blob/17c12da558d23d70e4c728b30958e95cd616cbcb/tools/assimp_cmd/Export.cpp#L54) seems to indicate we need to pass `-f<h>` where `<h>` is the format. And it can't infer since the extension for format `glb2` is `.glb`: [code/Common/Exporter.cpp:188](https://github.com/assimp/assimp/blob/17c12da558d23d70e4c728b30958e95cd616cbcb/code/Common/Exporter.cpp#L188). That's in line with the spec: https://github.com/KhronosGroup/glTF/blob/main/specification/2.0/Specification.adoc

But if you just use `glb2` with `-fglb2`, then the output from ConvertX is a `.glb2` file which must be renamed, so I altered the `normalizeOutputFiletype` function to handle these filetypes in assimp.

<img width="1840" height="1117" alt="Screenshot 2026-04-22 at 1 19 34 PM" src="https://github.com/user-attachments/assets/68641b1f-d719-4d50-920a-cd7cb3843f18" />

Shows this working in my self-hosted ConvertX instance.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pass `-f<format>` to `assimp export` so non-extension format IDs (e.g., `glb2`, `stlb`) export reliably, and write real file extensions so outputs open in viewers.

- **Bug Fixes**
  - Always call `assimp export` with `-f${convertTo}` to bypass extension inference and fix failures for non-extension targets (`glb2`, `gltf2`, `objnomtl`, `stlb`, `plyb`, `fbxa`, `assjson`).
  - Normalize output filenames: `glb2`→`.glb`, `gltf2`→`.gltf`, `objnomtl`→`.obj`, `stlb`→`.stl`, `plyb`→`.ply`, `fbxa`→`.fbx`, `assjson`→`.json`.

- **Refactors**
  - Prettier formatting in `assimp.ts` (no behavior changes).

<sup>Written for commit f7bbe717a2dbbe16104fa94cb74ccba228acfb9a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

