### PR TITLE
feat: allow configuring internal port via CONVERTX_PORT

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -65,7 +65,7 @@ if (process.env.NODE_ENV !== "production") {
   });
 }
 
-app.listen(process.env.PORT || 3000);
+app.listen(process.env.CONVERTX_PORT || process.env.PORT || 3000);
 
 console.log(`🦊 Elysia is running at http://${app.server?.hostname}:${app.server?.port}${WEBROOT}`);
 


### PR DESCRIPTION
Update index.tsx for feat: allow configuring internal port via CONVERTX_PORT

### Description
This PR updates the server initialization line to check for a dedicated `CONVERTX_PORT` environment variable before falling back to `PORT` or the default `3000`.

### Motivation
While ConvertX already supports the generic `PORT` environment variable, adding a container-specific variable (`CONVERTX_PORT`) provides distinct advantages for advanced homelab deployments:
1. **Host Networking Layering (`network_mode: host`):** Essential for deployments where using a generic `PORT` variable can cause unintended environment leakage or conflicts across multiple containers sharing the host network namespace.
2. **Explicit Configuration:** Makes docker-compose files and Podman Quadlets much easier to read and maintain by keeping environment variables distinct to their specific applications.

### Backward Compatibility
This change utilizes a standard fallback chain (`process.env.CONVERTX_PORT || process.env.PORT || 3000`). If neither variable is set, the application continues to default to `3000`. Existing installations and deployments relying on the generic `PORT` variable will experience zero breaking changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow configuring the server’s internal port via `CONVERTX_PORT`, falling back to `PORT` and then `3000`. This improves container deployments with explicit app ports while keeping full backward compatibility (CONVERTX_PORT -> PORT -> 3000).

<sup>Written for commit c18c8000babe44a574f1cd5d1466a3bec7df69e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/C4illin/ConvertX/pull/564?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

