### PR TITLE
fix: add CJK font support for PDF conversion

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,9 +73,11 @@ RUN apt-get update && apt-get install -y \
   resvg \
   texlive \
   texlive-fonts-recommended \
+  texlive-lang-chinese \
   texlive-latex-extra \
   texlive-latex-recommended \
   texlive-xetex \
+  fonts-noto-cjk \
   python3 \
   python3-pip \
   pipx \

--- a/src/converters/pandoc.ts
+++ b/src/converters/pandoc.ts
@@ -136,6 +136,11 @@ export function convert(
 
   if (xelatex.includes(convertTo)) {
     args.push("--pdf-engine=xelatex");
+    // Specify a CJK-capable main font so that documents containing Chinese,
+    // Japanese or Korean characters render correctly instead of producing
+    // blank/missing glyphs. "Noto Sans CJK SC" is provided by the
+    // fonts-noto-cjk package installed in the Dockerfile.
+    args.push("-V", "CJKmainfont=Noto Sans CJK SC");
   }
 
   args.push(filePath);

--- a/src/converters/pandoc.ts
+++ b/src/converters/pandoc.ts
@@ -122,6 +122,13 @@ export const properties = {
 };
 
 /**
+ * Input formats whose files are binary or compressed (ZIP-based) and cannot
+ * be reliably scanned for CJK characters by reading raw bytes. For these
+ * formats, a CJK font is always passed to avoid missing glyphs.
+ */
+const binaryFormats = new Set(["docx", "epub", "odt", "pptx"]);
+
+/**
  * Detects CJK characters in a file and returns the appropriate Noto Sans CJK
  * font variant for the detected language. Returns null for non-CJK content
  * so that the CJK font argument is omitted entirely, keeping non-CJK
@@ -176,11 +183,18 @@ export function convert(
 
   if (xelatex.includes(convertTo)) {
     args.push("--pdf-engine=xelatex");
-    // Detect CJK characters in the source file and set an appropriate
-    // CJK font only when needed. This avoids breaking non-CJK conversions
-    // in environments without CJK fonts, and selects the correct locale-
-    // specific font variant (JP/KR/SC) for proper glyph rendering.
-    const cjkFont = detectCJKFont(filePath);
+    // For binary/compressed formats (docx, epub, etc.), the raw file bytes
+    // cannot be scanned for CJK characters, so always pass a CJK font.
+    // For text-based formats, detect CJK characters to select the correct
+    // locale-specific font variant (JP/KR/SC) and to avoid adding a CJK
+    // font when the document contains none, keeping non-CJK conversions
+    // working in environments without CJK fonts installed.
+    let cjkFont: string | null;
+    if (binaryFormats.has(fileType.toLowerCase())) {
+      cjkFont = "Noto Sans CJK SC";
+    } else {
+      cjkFont = detectCJKFont(filePath);
+    }
     if (cjkFont) {
       args.push("-V", `CJKmainfont=${cjkFont}`);
     }

--- a/src/converters/pandoc.ts
+++ b/src/converters/pandoc.ts
@@ -1,4 +1,5 @@
 import { execFile as execFileOriginal } from "node:child_process";
+import { readFileSync } from "node:fs";
 import { ExecFileFn } from "./types";
 
 export const properties = {
@@ -120,6 +121,45 @@ export const properties = {
   },
 };
 
+/**
+ * Detects CJK characters in a file and returns the appropriate Noto Sans CJK
+ * font variant for the detected language. Returns null for non-CJK content
+ * so that the CJK font argument is omitted entirely, keeping non-CJK
+ * conversions working in environments without CJK fonts installed.
+ *
+ * Detection order matters: Japanese Kana is checked first (most specific),
+ * then Korean Hangul, then CJK Unified Ideographs (Chinese). This is because
+ * Japanese text also uses Kanji (shared with Chinese), but the presence of
+ * Kana uniquely identifies Japanese content.
+ */
+function detectCJKFont(filePath: string): string | null {
+  let content: string;
+  try {
+    content = readFileSync(filePath, "utf-8");
+  } catch {
+    // If the file can't be read, don't add a CJK font to avoid breaking
+    // conversions. Pandoc will still process the file independently.
+    return null;
+  }
+
+  // Japanese: Hiragana (U+3040-309F) or Katakana (U+30A0-30FF)
+  if (/[\u3040-\u309f\u30a0-\u30ff]/.test(content)) {
+    return "Noto Sans CJK JP";
+  }
+
+  // Korean: Hangul Syllables (U+AC00-D7AF)
+  if (/[\uac00-\ud7af]/.test(content)) {
+    return "Noto Sans CJK KR";
+  }
+
+  // Chinese: CJK Unified Ideographs (U+4E00-9FFF)
+  if (/[\u4e00-\u9fff]/.test(content)) {
+    return "Noto Sans CJK SC";
+  }
+
+  return null;
+}
+
 export function convert(
   filePath: string,
   fileType: string,
@@ -136,11 +176,14 @@ export function convert(
 
   if (xelatex.includes(convertTo)) {
     args.push("--pdf-engine=xelatex");
-    // Specify a CJK-capable main font so that documents containing Chinese,
-    // Japanese or Korean characters render correctly instead of producing
-    // blank/missing glyphs. "Noto Sans CJK SC" is provided by the
-    // fonts-noto-cjk package installed in the Dockerfile.
-    args.push("-V", "CJKmainfont=Noto Sans CJK SC");
+    // Detect CJK characters in the source file and set an appropriate
+    // CJK font only when needed. This avoids breaking non-CJK conversions
+    // in environments without CJK fonts, and selects the correct locale-
+    // specific font variant (JP/KR/SC) for proper glyph rendering.
+    const cjkFont = detectCJKFont(filePath);
+    if (cjkFont) {
+      args.push("-V", `CJKmainfont=${cjkFont}`);
+    }
   }
 
   args.push(filePath);

--- a/tests/converters/pandoc.test.ts
+++ b/tests/converters/pandoc.test.ts
@@ -1,9 +1,34 @@
-import { beforeEach, expect, test, describe } from "bun:test";
+import { beforeEach, expect, test, describe, afterEach } from "bun:test";
 import { convert } from "../../src/converters/pandoc";
 import type { ExecFileFn } from "../../src/converters/types";
+import { writeFileSync, unlinkSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 
 describe("convert", () => {
   let mockExecFile: ExecFileFn;
+  let tempFiles: string[] = [];
+
+  afterEach(() => {
+    for (const f of tempFiles) {
+      try {
+        unlinkSync(f);
+      } catch {
+        /* ignore */
+      }
+    }
+    tempFiles = [];
+  });
+
+  function makeTempFile(content: string, ext = "md"): string {
+    const path = join(
+      tmpdir(),
+      `pandoc-test-${Date.now()}-${Math.random().toString(36).slice(2)}.${ext}`,
+    );
+    writeFileSync(path, content, "utf-8");
+    tempFiles.push(path);
+    return path;
+  }
 
   beforeEach(() => {
     mockExecFile = (cmd, args, callback) => callback(null, "output-data", "");
@@ -45,10 +70,11 @@ describe("convert", () => {
       callback(null, "output-data", "");
     };
 
-    await convert("input.md", "markdown", "pdf", "output.pdf", undefined, mockExecFile);
+    const filePath = makeTempFile("# Hello World\n");
+    await convert(filePath, "markdown", "pdf", "output.pdf", undefined, mockExecFile);
 
     expect(calledArgs[1][0]).toBe("--pdf-engine=xelatex");
-    expect(calledArgs[1]).toContain("input.md");
+    expect(calledArgs[1]).toContain(filePath);
     expect(calledArgs[1]).toContain("-f");
     expect(calledArgs[1]).toContain("markdown");
     expect(calledArgs[1]).toContain("-t");
@@ -57,33 +83,85 @@ describe("convert", () => {
     expect(calledArgs[1]).toContain("output.pdf");
   });
 
-  test("should add CJK mainfont argument for pdf output", async () => {
+  test("should not add CJK mainfont for non-CJK content", async () => {
     let calledArgs: Parameters<ExecFileFn> = ["", [], () => {}];
     mockExecFile = (cmd, args, callback) => {
       calledArgs = [cmd, args, callback];
       callback(null, "output-data", "");
     };
 
-    await convert("input.md", "markdown", "pdf", "output.pdf", undefined, mockExecFile);
+    const filePath = makeTempFile("# Hello World\nThis is English text.\n");
+    await convert(filePath, "markdown", "pdf", "output.pdf", undefined, mockExecFile);
 
-    const cjkFontIndex = calledArgs[1].indexOf("-V");
-    expect(cjkFontIndex).toBeGreaterThan(-1);
-    expect(calledArgs[1][cjkFontIndex + 1]).toBe("CJKmainfont=Noto Sans CJK SC");
+    expect(calledArgs[1].some((arg) => arg.startsWith("CJKmainfont"))).toBe(false);
   });
 
-  test("should add CJK mainfont argument for latex output", async () => {
+  test("should add CJKmainfont=SC for Chinese content", async () => {
     let calledArgs: Parameters<ExecFileFn> = ["", [], () => {}];
     mockExecFile = (cmd, args, callback) => {
       calledArgs = [cmd, args, callback];
       callback(null, "output-data", "");
     };
 
-    await convert("input.md", "markdown", "latex", "output.tex", undefined, mockExecFile);
+    const filePath = makeTempFile("# 中文标题\n这是一段中文内容。\n");
+    await convert(filePath, "markdown", "pdf", "output.pdf", undefined, mockExecFile);
+
+    expect(calledArgs[1].some((arg) => arg === "CJKmainfont=Noto Sans CJK SC")).toBe(true);
+  });
+
+  test("should add CJKmainfont=JP for Japanese content", async () => {
+    let calledArgs: Parameters<ExecFileFn> = ["", [], () => {}];
+    mockExecFile = (cmd, args, callback) => {
+      calledArgs = [cmd, args, callback];
+      callback(null, "output-data", "");
+    };
+
+    const filePath = makeTempFile("# 日本語タイトル\nこれは日本語の内容です。\n");
+    await convert(filePath, "markdown", "pdf", "output.pdf", undefined, mockExecFile);
+
+    expect(calledArgs[1].some((arg) => arg === "CJKmainfont=Noto Sans CJK JP")).toBe(true);
+  });
+
+  test("should add CJKmainfont=KR for Korean content", async () => {
+    let calledArgs: Parameters<ExecFileFn> = ["", [], () => {}];
+    mockExecFile = (cmd, args, callback) => {
+      calledArgs = [cmd, args, callback];
+      callback(null, "output-data", "");
+    };
+
+    const filePath = makeTempFile("# 한국어 제목\n이것은 한국어 내용입니다.\n");
+    await convert(filePath, "markdown", "pdf", "output.pdf", undefined, mockExecFile);
+
+    expect(calledArgs[1].some((arg) => arg === "CJKmainfont=Noto Sans CJK KR")).toBe(true);
+  });
+
+  test("should prefer Japanese font when both Kanji and Kana present", async () => {
+    let calledArgs: Parameters<ExecFileFn> = ["", [], () => {}];
+    mockExecFile = (cmd, args, callback) => {
+      calledArgs = [cmd, args, callback];
+      callback(null, "output-data", "");
+    };
+
+    // Japanese text with both Kanji and Hiragana
+    const filePath = makeTempFile("# 日本語のテスト\nこれは漢字とひらがなの文章です。\n");
+    await convert(filePath, "markdown", "pdf", "output.pdf", undefined, mockExecFile);
+
+    expect(calledArgs[1].some((arg) => arg === "CJKmainfont=Noto Sans CJK JP")).toBe(true);
+    expect(calledArgs[1].some((arg) => arg === "CJKmainfont=Noto Sans CJK SC")).toBe(false);
+  });
+
+  test("should not add CJK mainfont for latex when content is non-CJK", async () => {
+    let calledArgs: Parameters<ExecFileFn> = ["", [], () => {}];
+    mockExecFile = (cmd, args, callback) => {
+      calledArgs = [cmd, args, callback];
+      callback(null, "output-data", "");
+    };
+
+    const filePath = makeTempFile("# English Title\nSome text.\n");
+    await convert(filePath, "markdown", "latex", "output.tex", undefined, mockExecFile);
 
     expect(calledArgs[1][0]).toBe("--pdf-engine=xelatex");
-    const cjkFontIndex = calledArgs[1].indexOf("-V");
-    expect(cjkFontIndex).toBeGreaterThan(-1);
-    expect(calledArgs[1][cjkFontIndex + 1]).toBe("CJKmainfont=Noto Sans CJK SC");
+    expect(calledArgs[1].some((arg) => arg.startsWith("CJKmainfont"))).toBe(false);
   });
 
   test("should not add CJK mainfont for non-pdf/latex output", async () => {
@@ -93,15 +171,31 @@ describe("convert", () => {
       callback(null, "output-data", "");
     };
 
-    await convert("input.md", "markdown", "html", "output.html", undefined, mockExecFile);
+    const filePath = makeTempFile("# 中文标题\n");
+    await convert(filePath, "markdown", "html", "output.html", undefined, mockExecFile);
 
     expect(calledArgs[1].some((arg) => arg.startsWith("CJKmainfont"))).toBe(false);
   });
 
+  test("should handle unreadable file gracefully without CJK font", async () => {
+    let calledArgs: Parameters<ExecFileFn> = ["", [], () => {}];
+    mockExecFile = (cmd, args, callback) => {
+      calledArgs = [cmd, args, callback];
+      callback(null, "output-data", "");
+    };
+
+    // Use a non-existent file path
+    await convert("/nonexistent/file.md", "markdown", "pdf", "output.pdf", undefined, mockExecFile);
+
+    expect(calledArgs[1][0]).toBe("--pdf-engine=xelatex");
+    expect(calledArgs[1].some((arg) => arg.startsWith("CJKmainfont"))).toBe(false);
+  });
+
   test("should reject if execFile returns an error", async () => {
+    const filePath = makeTempFile("# Test\n");
     mockExecFile = (cmd, args, callback) => callback(new Error("fail"), "", "");
     await expect(
-      convert("input.md", "markdown", "html", "output.html", undefined, mockExecFile),
+      convert(filePath, "markdown", "html", "output.html", undefined, mockExecFile),
     ).rejects.toMatch(/error: Error: fail/);
   });
 });

--- a/tests/converters/pandoc.test.ts
+++ b/tests/converters/pandoc.test.ts
@@ -57,6 +57,47 @@ describe("convert", () => {
     expect(calledArgs[1]).toContain("output.pdf");
   });
 
+  test("should add CJK mainfont argument for pdf output", async () => {
+    let calledArgs: Parameters<ExecFileFn> = ["", [], () => {}];
+    mockExecFile = (cmd, args, callback) => {
+      calledArgs = [cmd, args, callback];
+      callback(null, "output-data", "");
+    };
+
+    await convert("input.md", "markdown", "pdf", "output.pdf", undefined, mockExecFile);
+
+    const cjkFontIndex = calledArgs[1].indexOf("-V");
+    expect(cjkFontIndex).toBeGreaterThan(-1);
+    expect(calledArgs[1][cjkFontIndex + 1]).toBe("CJKmainfont=Noto Sans CJK SC");
+  });
+
+  test("should add CJK mainfont argument for latex output", async () => {
+    let calledArgs: Parameters<ExecFileFn> = ["", [], () => {}];
+    mockExecFile = (cmd, args, callback) => {
+      calledArgs = [cmd, args, callback];
+      callback(null, "output-data", "");
+    };
+
+    await convert("input.md", "markdown", "latex", "output.tex", undefined, mockExecFile);
+
+    expect(calledArgs[1][0]).toBe("--pdf-engine=xelatex");
+    const cjkFontIndex = calledArgs[1].indexOf("-V");
+    expect(cjkFontIndex).toBeGreaterThan(-1);
+    expect(calledArgs[1][cjkFontIndex + 1]).toBe("CJKmainfont=Noto Sans CJK SC");
+  });
+
+  test("should not add CJK mainfont for non-pdf/latex output", async () => {
+    let calledArgs: Parameters<ExecFileFn> = ["", [], () => {}];
+    mockExecFile = (cmd, args, callback) => {
+      calledArgs = [cmd, args, callback];
+      callback(null, "output-data", "");
+    };
+
+    await convert("input.md", "markdown", "html", "output.html", undefined, mockExecFile);
+
+    expect(calledArgs[1].some((arg) => arg.startsWith("CJKmainfont"))).toBe(false);
+  });
+
   test("should reject if execFile returns an error", async () => {
     mockExecFile = (cmd, args, callback) => callback(new Error("fail"), "", "");
     await expect(

--- a/tests/converters/pandoc.test.ts
+++ b/tests/converters/pandoc.test.ts
@@ -169,38 +169,19 @@ describe("convert", () => {
     expect(calledArgs[1].some((arg) => arg.startsWith("CJKmainfont"))).toBe(false);
   });
 
-  test("should always add CJK font for docx binary format with -V adjacency", async () => {
-    let calledArgs: Parameters<ExecFileFn> = ["", [], () => {}];
-    mockExecFile = (cmd, args, callback) => {
-      calledArgs = [cmd, args, callback];
-      callback(null, "output-data", "");
-    };
-    const filePath = makeTempFile("binary placeholder content", "docx");
-    await convert(filePath, "docx", "pdf", "output.pdf", undefined, mockExecFile);
-    assertCJKFontArg(calledArgs[1], "Noto Sans CJK SC");
-  });
-
-  test("should always add CJK font for epub binary format with -V adjacency", async () => {
-    let calledArgs: Parameters<ExecFileFn> = ["", [], () => {}];
-    mockExecFile = (cmd, args, callback) => {
-      calledArgs = [cmd, args, callback];
-      callback(null, "output-data", "");
-    };
-    const filePath = makeTempFile("binary placeholder content", "epub");
-    await convert(filePath, "epub", "pdf", "output.pdf", undefined, mockExecFile);
-    assertCJKFontArg(calledArgs[1], "Noto Sans CJK SC");
-  });
-
-  test("should always add CJK font for odt binary format", async () => {
-    let calledArgs: Parameters<ExecFileFn> = ["", [], () => {}];
-    mockExecFile = (cmd, args, callback) => {
-      calledArgs = [cmd, args, callback];
-      callback(null, "output-data", "");
-    };
-    const filePath = makeTempFile("binary placeholder content", "odt");
-    await convert(filePath, "odt", "pdf", "output.pdf", undefined, mockExecFile);
-    assertCJKFontArg(calledArgs[1], "Noto Sans CJK SC");
-  });
+  test.each(["docx", "epub", "odt"])(
+    "should always add CJK font for %s binary format with -V adjacency",
+    async (format: string) => {
+      let calledArgs: Parameters<ExecFileFn> = ["", [], () => {}];
+      mockExecFile = (cmd, args, callback) => {
+        calledArgs = [cmd, args, callback];
+        callback(null, "output-data", "");
+      };
+      const filePath = makeTempFile("binary placeholder content", format);
+      await convert(filePath, format, "pdf", "output.pdf", undefined, mockExecFile);
+      assertCJKFontArg(calledArgs[1], "Noto Sans CJK SC");
+    },
+  );
 
   test("should reject if execFile returns an error", async () => {
     const filePath = makeTempFile("# Test\n");

--- a/tests/converters/pandoc.test.ts
+++ b/tests/converters/pandoc.test.ts
@@ -21,26 +21,31 @@ describe("convert", () => {
   });
 
   function makeTempFile(content: string, ext = "md"): string {
-    const path = join(
+    const p = join(
       tmpdir(),
       `pandoc-test-${Date.now()}-${Math.random().toString(36).slice(2)}.${ext}`,
     );
-    writeFileSync(path, content, "utf-8");
-    tempFiles.push(path);
-    return path;
+    writeFileSync(p, content, "utf-8");
+    tempFiles.push(p);
+    return p;
+  }
+
+  function assertCJKFontArg(args: string[], expectedFont: string) {
+    const idx = args.indexOf(`CJKmainfont=${expectedFont}`);
+    expect(idx).toBeGreaterThan(-1);
+    expect(args[idx - 1]).toBe("-V");
   }
 
   beforeEach(() => {
     mockExecFile = (cmd, args, callback) => callback(null, "output-data", "");
   });
 
-  test("should call pandoc with correct arguments (normal)", async () => {
+  test("should call pandoc with correct arguments", async () => {
     let calledArgs: Parameters<ExecFileFn> = ["", [], () => {}];
     mockExecFile = (cmd, args, callback) => {
       calledArgs = [cmd, args, callback];
       callback(null, "output-data", "");
     };
-
     const result = await convert(
       "input.md",
       "markdown",
@@ -49,7 +54,6 @@ describe("convert", () => {
       undefined,
       mockExecFile,
     );
-
     expect(calledArgs[0]).toBe("pandoc");
     expect(calledArgs[1]).toEqual([
       "input.md",
@@ -63,24 +67,16 @@ describe("convert", () => {
     expect(result).toBe("Done");
   });
 
-  test("should add xelatex argument for pdf/latex", async () => {
+  test("should add xelatex argument for pdf", async () => {
     let calledArgs: Parameters<ExecFileFn> = ["", [], () => {}];
     mockExecFile = (cmd, args, callback) => {
       calledArgs = [cmd, args, callback];
       callback(null, "output-data", "");
     };
-
     const filePath = makeTempFile("# Hello World\n");
     await convert(filePath, "markdown", "pdf", "output.pdf", undefined, mockExecFile);
-
     expect(calledArgs[1][0]).toBe("--pdf-engine=xelatex");
     expect(calledArgs[1]).toContain(filePath);
-    expect(calledArgs[1]).toContain("-f");
-    expect(calledArgs[1]).toContain("markdown");
-    expect(calledArgs[1]).toContain("-t");
-    expect(calledArgs[1]).toContain("pdf");
-    expect(calledArgs[1]).toContain("-o");
-    expect(calledArgs[1]).toContain("output.pdf");
   });
 
   test("should not add CJK mainfont for non-CJK content", async () => {
@@ -89,50 +85,42 @@ describe("convert", () => {
       calledArgs = [cmd, args, callback];
       callback(null, "output-data", "");
     };
-
     const filePath = makeTempFile("# Hello World\nThis is English text.\n");
     await convert(filePath, "markdown", "pdf", "output.pdf", undefined, mockExecFile);
-
     expect(calledArgs[1].some((arg) => arg.startsWith("CJKmainfont"))).toBe(false);
   });
 
-  test("should add CJKmainfont=SC for Chinese content", async () => {
+  test("should add CJKmainfont=SC for Chinese content with -V adjacency", async () => {
     let calledArgs: Parameters<ExecFileFn> = ["", [], () => {}];
     mockExecFile = (cmd, args, callback) => {
       calledArgs = [cmd, args, callback];
       callback(null, "output-data", "");
     };
-
     const filePath = makeTempFile("# 中文标题\n这是一段中文内容。\n");
     await convert(filePath, "markdown", "pdf", "output.pdf", undefined, mockExecFile);
-
-    expect(calledArgs[1].some((arg) => arg === "CJKmainfont=Noto Sans CJK SC")).toBe(true);
+    assertCJKFontArg(calledArgs[1], "Noto Sans CJK SC");
   });
 
-  test("should add CJKmainfont=JP for Japanese content", async () => {
+  test("should add CJKmainfont=JP for Japanese content with -V adjacency", async () => {
     let calledArgs: Parameters<ExecFileFn> = ["", [], () => {}];
     mockExecFile = (cmd, args, callback) => {
       calledArgs = [cmd, args, callback];
       callback(null, "output-data", "");
     };
-
     const filePath = makeTempFile("# 日本語タイトル\nこれは日本語の内容です。\n");
     await convert(filePath, "markdown", "pdf", "output.pdf", undefined, mockExecFile);
-
-    expect(calledArgs[1].some((arg) => arg === "CJKmainfont=Noto Sans CJK JP")).toBe(true);
+    assertCJKFontArg(calledArgs[1], "Noto Sans CJK JP");
   });
 
-  test("should add CJKmainfont=KR for Korean content", async () => {
+  test("should add CJKmainfont=KR for Korean content with -V adjacency", async () => {
     let calledArgs: Parameters<ExecFileFn> = ["", [], () => {}];
     mockExecFile = (cmd, args, callback) => {
       calledArgs = [cmd, args, callback];
       callback(null, "output-data", "");
     };
-
     const filePath = makeTempFile("# 한국어 제목\n이것은 한국어 내용입니다.\n");
     await convert(filePath, "markdown", "pdf", "output.pdf", undefined, mockExecFile);
-
-    expect(calledArgs[1].some((arg) => arg === "CJKmainfont=Noto Sans CJK KR")).toBe(true);
+    assertCJKFontArg(calledArgs[1], "Noto Sans CJK KR");
   });
 
   test("should prefer Japanese font when both Kanji and Kana present", async () => {
@@ -141,12 +129,9 @@ describe("convert", () => {
       calledArgs = [cmd, args, callback];
       callback(null, "output-data", "");
     };
-
-    // Japanese text with both Kanji and Hiragana
     const filePath = makeTempFile("# 日本語のテスト\nこれは漢字とひらがなの文章です。\n");
     await convert(filePath, "markdown", "pdf", "output.pdf", undefined, mockExecFile);
-
-    expect(calledArgs[1].some((arg) => arg === "CJKmainfont=Noto Sans CJK JP")).toBe(true);
+    assertCJKFontArg(calledArgs[1], "Noto Sans CJK JP");
     expect(calledArgs[1].some((arg) => arg === "CJKmainfont=Noto Sans CJK SC")).toBe(false);
   });
 
@@ -156,10 +141,8 @@ describe("convert", () => {
       calledArgs = [cmd, args, callback];
       callback(null, "output-data", "");
     };
-
     const filePath = makeTempFile("# English Title\nSome text.\n");
     await convert(filePath, "markdown", "latex", "output.tex", undefined, mockExecFile);
-
     expect(calledArgs[1][0]).toBe("--pdf-engine=xelatex");
     expect(calledArgs[1].some((arg) => arg.startsWith("CJKmainfont"))).toBe(false);
   });
@@ -170,10 +153,8 @@ describe("convert", () => {
       calledArgs = [cmd, args, callback];
       callback(null, "output-data", "");
     };
-
     const filePath = makeTempFile("# 中文标题\n");
     await convert(filePath, "markdown", "html", "output.html", undefined, mockExecFile);
-
     expect(calledArgs[1].some((arg) => arg.startsWith("CJKmainfont"))).toBe(false);
   });
 
@@ -183,12 +164,42 @@ describe("convert", () => {
       calledArgs = [cmd, args, callback];
       callback(null, "output-data", "");
     };
-
-    // Use a non-existent file path
     await convert("/nonexistent/file.md", "markdown", "pdf", "output.pdf", undefined, mockExecFile);
-
     expect(calledArgs[1][0]).toBe("--pdf-engine=xelatex");
     expect(calledArgs[1].some((arg) => arg.startsWith("CJKmainfont"))).toBe(false);
+  });
+
+  test("should always add CJK font for docx binary format with -V adjacency", async () => {
+    let calledArgs: Parameters<ExecFileFn> = ["", [], () => {}];
+    mockExecFile = (cmd, args, callback) => {
+      calledArgs = [cmd, args, callback];
+      callback(null, "output-data", "");
+    };
+    const filePath = makeTempFile("binary placeholder content", "docx");
+    await convert(filePath, "docx", "pdf", "output.pdf", undefined, mockExecFile);
+    assertCJKFontArg(calledArgs[1], "Noto Sans CJK SC");
+  });
+
+  test("should always add CJK font for epub binary format with -V adjacency", async () => {
+    let calledArgs: Parameters<ExecFileFn> = ["", [], () => {}];
+    mockExecFile = (cmd, args, callback) => {
+      calledArgs = [cmd, args, callback];
+      callback(null, "output-data", "");
+    };
+    const filePath = makeTempFile("binary placeholder content", "epub");
+    await convert(filePath, "epub", "pdf", "output.pdf", undefined, mockExecFile);
+    assertCJKFontArg(calledArgs[1], "Noto Sans CJK SC");
+  });
+
+  test("should always add CJK font for odt binary format", async () => {
+    let calledArgs: Parameters<ExecFileFn> = ["", [], () => {}];
+    mockExecFile = (cmd, args, callback) => {
+      calledArgs = [cmd, args, callback];
+      callback(null, "output-data", "");
+    };
+    const filePath = makeTempFile("binary placeholder content", "odt");
+    await convert(filePath, "odt", "pdf", "output.pdf", undefined, mockExecFile);
+    assertCJKFontArg(calledArgs[1], "Noto Sans CJK SC");
   });
 
   test("should reject if execFile returns an error", async () => {


### PR DESCRIPTION
## Summary

When converting documents containing Chinese, Japanese, or Korean characters to PDF via pandoc/xelatex, the output was blank or missing glyphs because no CJK-capable font was installed or configured in the Docker image.

## Changes

- **`Dockerfile`**: Add `fonts-noto-cjk` and `texlive-lang-chinese` packages to provide CJK fonts in the Docker image
- **`src/converters/pandoc.ts`**: Pass `-V CJKmainfont=Noto Sans CJK SC` to pandoc when converting to pdf/latex, so xelatex uses a CJK-capable font for rendering
- **`tests/converters/pandoc.test.ts`**: Add 3 new tests:
  - Verifies CJK font argument is present for PDF output
  - Verifies CJK font argument is present for LaTeX output
  - Verifies CJK font argument is absent for non-pdf/latex output (e.g., HTML)

## Testing

- Prettier: passes
- ESLint: passes (0 errors)
- TypeScript: passes (`tsc --noEmit`)
- Tests: 6/6 pass (`bun test tests/converters/pandoc.test.ts`)

Fixes #547

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix PDF/LaTeX rendering of Chinese, Japanese, and Korean by installing CJK fonts and using `xelatex`, selecting a locale-aware Noto Sans CJK font only when needed and defaulting to SC for binary inputs. Fixes #547.

- **Bug Fixes**
  - Dockerfile: add `fonts-noto-cjk` and `texlive-lang-chinese`.
  - Converter: use `xelatex`; detect JP/KR/SC for text inputs; always pass `-V CJKmainfont=Noto Sans CJK SC` for `docx`/`epub`/`odt`/`pptx`; skip font if the file can’t be read.
  - Tests: add JP/KR/SC detection and non-CJK cases; add binary format cases; verify `-V` precedes `CJKmainfont`.

- **Refactors**
  - Tests: consolidate binary format tests with test.each and unify test names.

<sup>Written for commit f161f682405768cc988dc6c2840b1528615cbe2b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/C4illin/ConvertX/pull/571?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

