### PR TITLE
chore: add missing PORT environment variable to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ All are optional, JWT_SECRET is recommended to be set.
 
 | Name                         | Default                                            | Description                                                                                                                                                   |
 | ---------------------------- | -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| PORT                         | 3000                                               | Application listen port                                                                                                                                       |
 | JWT_SECRET                   | when unset it will use the value from randomUUID() | A long and secret string used to sign the JSON Web Token                                                                                                      |
 | ACCOUNT_REGISTRATION         | false                                              | Allow users to register accounts                                                                                                                              |
 | HTTP_ALLOWED                 | false                                              | Allow HTTP connections, only set this to true locally                                                                                                         |

--- a/README.md
+++ b/README.md
@@ -89,7 +89,6 @@ All are optional, JWT_SECRET is recommended to be set.
 
 | Name                         | Default                                            | Description                                                                                                                                                   |
 | ---------------------------- | -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| PORT                         | 3000                                               | Application listen port                                                                                                                                       |
 | JWT_SECRET                   | when unset it will use the value from randomUUID() | A long and secret string used to sign the JSON Web Token                                                                                                      |
 | ACCOUNT_REGISTRATION         | false                                              | Allow users to register accounts                                                                                                                              |
 | HTTP_ALLOWED                 | false                                              | Allow HTTP connections, only set this to true locally                                                                                                         |
@@ -102,6 +101,7 @@ All are optional, JWT_SECRET is recommended to be set.
 | LANGUAGE                     | en                                                 | Language to format date strings in, specified as a [BCP 47 language tag](https://en.wikipedia.org/wiki/IETF_language_tag)                                     |
 | UNAUTHENTICATED_USER_SHARING | false                                              | Shares conversion history between all unauthenticated users                                                                                                   |
 | MAX_CONVERT_PROCESS          | 0                                                  | Maximum number of concurrent conversion processes allowed. Set to 0 for unlimited.                                                                            |
+| PORT                         | 3000                                               | Application listen port                                                                                                                                       |
 
 ### Docker images
 


### PR DESCRIPTION
Add missing `PORT` environment variable which was added in #530 to `README.md`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents the missing `PORT` environment variable in the README with a default of 3000 so users can set the application listen port. Also reorders the environment variable table for consistency.

<sup>Written for commit cdf2beb06eec4cbf7a80674fdb2d7dd4ee8559d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/C4illin/ConvertX/pull/576?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

