### PR TITLE
Apply EXIF orientation when converting images with ImageMagick

### DIFF
--- a/src/converters/imagemagick.ts
+++ b/src/converters/imagemagick.ts
@@ -468,6 +468,10 @@ export function convert(
     outputArgs.push("-background", "white", "-alpha", "remove");
   }
 
+  // Apply EXIF orientation so photos (e.g. from phones) don't end up sideways
+  // when converted to formats where the orientation tag is lost or ignored
+  outputArgs.push("-auto-orient");
+
   return new Promise((resolve, reject) => {
     execFile(
       "magick",

--- a/tests/converters/imagemagick.test.ts
+++ b/tests/converters/imagemagick.test.ts
@@ -163,3 +163,19 @@ test("convert respects emf as input filetype", async () => {
   );
   expect(loggedMessage).toBe("stdout: Fake stdout");
 });
+
+test("convert applies EXIF auto-orient", async () => {
+  const mockExecFile: ExecFileFn = (
+    _cmd: string,
+    _args: string[],
+    callback: (err: ExecFileException | null, stdout: string, stderr: string) => void,
+  ) => {
+    calls.push(_args);
+    callback(null, "", "");
+  };
+
+  const result = await convert("input.jpg", "jpg", "png", "output.png", undefined, mockExecFile);
+
+  expect(result).toBe("Done");
+  expect(calls[0]).toEqual(expect.arrayContaining(["input.jpg", "-auto-orient", "output.png"]));
+});


### PR DESCRIPTION
Photos taken on phones (iPhone DNG/JPEG, Android, most cameras) store pixels unrotated with an EXIF `Orientation` tag. When converting to formats where that tag is lost or ignored (png, webp, ...), the output comes out sideways.

This adds `-auto-orient` to the magick invocation so pixels are physically rotated according to the tag before writing the output.

Verified with [exif-orientation-examples](https://github.com/recurser/exif-orientation-examples): `Landscape_6.jpg` (1200x1800 stored, orientation=RightTop) now converts to an upright 1800x1200 png instead of a sideways one. Added a unit test.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes sideways exports by applying EXIF Orientation during conversion. Adds ImageMagick auto-orientation so phone photos output upright in PNG/WebP and other formats that ignore EXIF.

- **Bug Fixes**
  - Add `-auto-orient` to the `magick` command to rotate pixels before writing output.
  - Add a unit test to verify `-auto-orient` is passed during JPG→PNG conversion.

<sup>Written for commit 0b9c58c8cf69cbb8d237dca5194141c981ed05d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/C4illin/ConvertX/pull/577?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

