### PR TITLE
fix(libreoffice): don't force MS Word 97 infilter on .wps

### DIFF
--- a/src/converters/libreoffice.ts
+++ b/src/converters/libreoffice.ts
@@ -117,6 +117,15 @@ const filters: Record<FileCategories, Record<string, string | null>> = {
     // filter makes soffice reject a genuine Works document with "source file
     // could not be loaded", even though it converts the same file fine with
     // no --infilter at all (LibreOffice auto-detects it correctly).
+    //
+    // null is deliberate for BOTH directions here, not just the import side:
+    // this map feeds both --infilter (import) and the --convert-to suffix
+    // (export). On import, null lets LibreOffice auto-detect - its Works
+    // import filter (MS_Works, libwps-backed) is import-only, so it can only
+    // be reached via auto-detection anyway. On export, LibreOffice has no
+    // Works export filter at all; bare `--convert-to wps` falls back to its
+    // default export filter for the extension, which is "MS Word 97" - the
+    // exact filter this map pinned before, so export output is unchanged.
     wps: null,
     wpt: "MS Word 97 Vorlage",
     wri: "MS_Write",

--- a/src/converters/libreoffice.ts
+++ b/src/converters/libreoffice.ts
@@ -77,7 +77,7 @@ export const properties = {
 
 type FileCategories = "text" | "calc";
 
-const filters: Record<FileCategories, Record<string, string>> = {
+const filters: Record<FileCategories, Record<string, string | null>> = {
   text: {
     "602": "T602Document",
     abw: "AbiWord",
@@ -113,7 +113,11 @@ const filters: Record<FileCategories, Record<string, string>> = {
     txt: "Text",
     wn: "WriteNow",
     wpd: "WordPerfect",
-    wps: "MS Word 97",
+    // .wps is Microsoft Works, not MS Word 97/.doc - forcing the "MS Word 97"
+    // filter makes soffice reject a genuine Works document with "source file
+    // could not be loaded", even though it converts the same file fine with
+    // no --infilter at all (LibreOffice auto-detects it correctly).
+    wps: null,
     wpt: "MS Word 97 Vorlage",
     wri: "MS_Write",
     xhtml: "HTML (StarWriter)",

--- a/tests/converters/libreoffice.test.ts
+++ b/tests/converters/libreoffice.test.ts
@@ -102,6 +102,26 @@ test("uses only infilter when convertTo has no out filter (e.g., docx -> pdf)", 
   expect(args.slice(-2)).toEqual(["out", "in.docx"]);
 });
 
+test("does not force an infilter for wps (Microsoft Works, not MS Word 97)", async () => {
+  // Regression test for https://github.com/C4illin/ConvertX/issues/582 -
+  // forcing --infilter="MS Word 97" on a genuine .wps file makes soffice
+  // reject it with "source file could not be loaded". No forced infilter
+  // lets LibreOffice auto-detect the real format instead.
+  await convert("in.wps", "wps", "docx", "out/out.docx", undefined, mockExecFile);
+
+  const { args } = requireDefined(calls[0], "Expected at least one execFile call");
+
+  expect(args).toEqual([
+    "--headless",
+    "--convert-to",
+    "docx:MS Word 2007 XML",
+    "--outdir",
+    "out",
+    "in.wps",
+  ]);
+  expect(args.some((a) => a.startsWith("--infilter"))).toBe(false);
+});
+
 test("strips leading './' from outdir", async () => {
   await convert("in.txt", "txt", "docx", "./out/out.docx", undefined, mockExecFile);
 

--- a/tests/converters/libreoffice.test.ts
+++ b/tests/converters/libreoffice.test.ts
@@ -122,6 +122,29 @@ test("does not force an infilter for wps (Microsoft Works, not MS Word 97)", asy
   expect(args.some((a) => a.startsWith("--infilter"))).toBe(false);
 });
 
+test("does not force an outfilter for wps as an export target either", async () => {
+  // wps shares one filter-map entry for both directions (see the comment in
+  // libreoffice.ts) - docx's own infilter is still emitted (that describes
+  // the real source file), but no --convert-to wps:<filter> suffix is
+  // forced. Verified against a real soffice: this exact invocation succeeds,
+  // with LibreOffice's default export filter for .wps ("MS Word 97" - the
+  // same filter the map pinned before this change, so output is unchanged).
+  // LibreOffice has no Works export filter, so no suffix could do better.
+  await convert("in.docx", "docx", "wps", "out/out.wps", undefined, mockExecFile);
+
+  const { args } = requireDefined(calls[0], "Expected at least one execFile call");
+
+  expect(args).toEqual([
+    "--headless",
+    "--infilter=MS Word 2007 XML",
+    "--convert-to",
+    "wps",
+    "--outdir",
+    "out",
+    "in.docx",
+  ]);
+});
+
 test("strips leading './' from outdir", async () => {
   await convert("in.txt", "txt", "docx", "./out/out.docx", undefined, mockExecFile);
 


### PR DESCRIPTION
Fixes #582

## Problem
`src/converters/libreoffice.ts` maps the `wps` source format to LibreOffice's `"MS Word 97"` import filter. `.wps` is Microsoft Works, not MS Word 97/.doc — forcing that filter makes `soffice` reject a genuine Works document with `Error: source file could not be loaded`, even though the same file converts cleanly when no `--infilter` is passed at all (LibreOffice auto-detects the real format).

Confirmed directly against a real `.wps` file:
```
$ soffice --headless --infilter="MS Word 97" --convert-to docx:"MS Word 2007 XML" --outdir /tmp "file.wps"
Error: source file could not be loaded

$ soffice --headless --convert-to docx:"MS Word 2007 XML" --outdir /tmp "file.wps"
convert /tmp/file.wps as a Writer document -> /tmp/file.docx using filter : MS Word 2007 XML   # succeeds
```

## Fix
Set `wps: null` in the filter map so `getFilters()` skips `--infilter` entirely for `.wps`, letting LibreOffice auto-detect the format (same mechanism already used for pdf-target conversions). Widened the map's value type to `string | null` to allow it.

## Testing
Added a regression test asserting no `--infilter` flag is emitted for a `wps -> docx` conversion. Ran the full suite plus `tsc --noEmit` locally — both clean:
```
bun test v1.3.14
 11 pass
 0 fail
Ran 11 tests across 1 file.
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop forcing the MS Word 97 filter on `.wps` in the LibreOffice converter. Auto-detect Works on import and keep default behavior on export to prevent failed conversions.

- **Bug Fixes**
  - Map `wps` to `null` and widen the filter map type to `string | null`.
  - Import: no `--infilter` so LibreOffice auto-detects Works.
  - Export: emit `--convert-to wps` without a suffix (defaults to MS Word 97); added tests for `wps -> docx` and `docx -> wps`.

<sup>Written for commit 4600ff0f1fe88af842340d561b4e0ba50c0dc753. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/C4illin/ConvertX/pull/585?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

