### PR TITLE
fix(results): encode download filenames

### DIFF
--- a/src/helpers/buildDownloadUrl.ts
+++ b/src/helpers/buildDownloadUrl.ts
@@ -1,0 +1,3 @@
+export function buildDownloadUrl(webroot: string, outputPath: string, fileName: string): string {
+  return `${webroot}/download/${outputPath}${encodeURIComponent(fileName)}`;
+}

--- a/src/pages/results.tsx
+++ b/src/pages/results.tsx
@@ -3,6 +3,7 @@ import { BaseHtml } from "../components/base";
 import { Header } from "../components/header";
 import db from "../db/db";
 import { Filename, Jobs } from "../db/types";
+import { buildDownloadUrl } from "../helpers/buildDownloadUrl";
 import { ALLOW_UNAUTHENTICATED, WEBROOT } from "../helpers/env";
 import { DownloadIcon } from "../icons/download";
 import { DeleteIcon } from "../icons/delete";
@@ -107,7 +108,7 @@ function ResultsArticle({
                     text-accent-500 underline
                     hover:text-accent-400
                   `}
-                  href={`${WEBROOT}/download/${outputPath}${file.output_file_name}`}
+                  href={buildDownloadUrl(WEBROOT, outputPath, file.output_file_name)}
                 >
                   <EyeIcon />
                 </a>
@@ -116,7 +117,7 @@ function ResultsArticle({
                     text-accent-500 underline
                     hover:text-accent-400
                   `}
-                  href={`${WEBROOT}/download/${outputPath}${file.output_file_name}`}
+                  href={buildDownloadUrl(WEBROOT, outputPath, file.output_file_name)}
                   download={file.output_file_name}
                 >
                   <DownloadIcon />

--- a/tests/pages/results.test.ts
+++ b/tests/pages/results.test.ts
@@ -1,0 +1,12 @@
+import { expect, test } from "bun:test";
+import { buildDownloadUrl } from "../../src/helpers/buildDownloadUrl";
+
+test("encodes reserved characters in download filenames", () => {
+  expect(buildDownloadUrl("", "1/2/", "clip #1?.gif")).toBe("/download/1/2/clip%20%231%3F.gif");
+});
+
+test("preserves output path segments while encoding the filename", () => {
+  expect(buildDownloadUrl("/convertx", "user/job/", "報告 100%.pdf")).toBe(
+    "/convertx/download/user/job/%E5%A0%B1%E5%91%8A%20100%25.pdf",
+  );
+});


### PR DESCRIPTION
## Summary

Encode the output filename as a single URL path segment before rendering preview and download links. This prevents `#` from starting a fragment and also handles other reserved characters without changing the trusted user/job path segments.

## Validation

- `bun test`: 100 passed, 8 skipped
- Added 2 regression tests for reserved characters and Unicode filenames
- `bun run lint:tsc`
- `bun run lint:knip`
- `bun run build`
- Changed files pass Prettier

Closes #578

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Encode download filenames as a single URL path segment so preview and download links work with #, spaces, and Unicode. Path segments (e.g., user/job) remain unchanged.

- **Bug Fixes**
  - Added `buildDownloadUrl` helper to encode only the filename.
  - Updated results page to use the helper for preview and download links.
  - Added tests for reserved characters and Unicode filenames.

<sup>Written for commit b9495de7dc87d914791e4def4cb92baf2266dcc3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/C4illin/ConvertX/pull/587?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

