### PR TITLE
fix(dasel): update converter for v3 CLI

### DIFF
--- a/src/converters/dasel.ts
+++ b/src/converters/dasel.ts
@@ -11,6 +11,10 @@ export const properties = {
   },
 };
 
+export function buildDaselArgs(filePath: string, fileType: string, convertTo: string): string[] {
+  return ["--var", `data=${fileType}:file:${filePath}`, "--out", convertTo, "$data"];
+}
+
 export async function convert(
   filePath: string,
   fileType: string,
@@ -19,14 +23,10 @@ export async function convert(
   options?: unknown,
   execFile: ExecFileFn = execFileOriginal, // to make it mockable
 ): Promise<string> {
-  const args: string[] = [];
-
-  args.push("--file", filePath);
-  args.push("--read", fileType);
-  args.push("--write", convertTo);
+  const args = buildDaselArgs(filePath, fileType, convertTo);
 
   return new Promise((resolve, reject) => {
-    execFile("dasel", args, (error, stdout, stderr) => {
+    const childProcess = execFile("dasel", args, (error, stdout, stderr) => {
       if (error) {
         reject(`error: ${error}`);
         return;
@@ -44,5 +44,7 @@ export async function convert(
         }
       });
     });
+
+    childProcess?.stdin?.end();
   });
 }

--- a/src/converters/types.ts
+++ b/src/converters/types.ts
@@ -1,11 +1,11 @@
-import { ExecFileOptions } from "child_process";
+import type { ChildProcess, ExecFileOptions } from "child_process";
 
 export type ExecFileFn = (
   cmd: string,
   args: string[],
   callback: (err: Error | null, stdout: string, stderr: string) => void,
   options?: ExecFileOptions,
-) => void;
+) => ChildProcess | void;
 
 export type ConvertFnWithExecFile = (
   filePath: string,

--- a/tests/converters/dasel.test.ts
+++ b/tests/converters/dasel.test.ts
@@ -1,6 +1,6 @@
 import fs from "fs";
 import { beforeEach, afterEach, expect, test, describe } from "bun:test";
-import { convert } from "../../src/converters/dasel";
+import { buildDaselArgs, convert } from "../../src/converters/dasel";
 import type { ExecFileFn } from "../../src/converters/types";
 
 const originalWriteFile = fs.writeFile;
@@ -19,6 +19,16 @@ describe("convert", () => {
   afterEach(() => {
     // reset fs.writeFile
     fs.writeFile = originalWriteFile;
+  });
+
+  test("should build dasel v3 arguments", () => {
+    expect(buildDaselArgs("input.yaml", "yaml", "json")).toEqual([
+      "--var",
+      "data=yaml:file:input.yaml",
+      "--out",
+      "json",
+      "$data",
+    ]);
   });
 
   test("should call dasel with correct arguments and write output", async () => {
@@ -48,9 +58,21 @@ describe("convert", () => {
     );
 
     expect(calledArgs[0]).toBe("dasel");
-    expect(calledArgs[1]).toEqual(["--file", "input.yaml", "--read", "yaml", "--write", "json"]);
+    expect(calledArgs[1]).toEqual(["--var", "data=yaml:file:input.yaml", "--out", "json", "$data"]);
     expect(writeFileCalled).toBe(true);
     expect(result).toBe("Done");
+  });
+
+  test("should close dasel stdin so v3 does not wait for input", async () => {
+    let stdinEnded = false;
+    mockExecFile = (cmd, args, callback) => {
+      callback(null, "output-data", "");
+      return { stdin: { end: () => (stdinEnded = true) } } as ReturnType<ExecFileFn>;
+    };
+
+    await convert("input.yaml", "yaml", "json", "output.json", undefined, mockExecFile);
+
+    expect(stdinEnded).toBe(true);
   });
 
   test("should reject if execFile returns an error", async () => {


### PR DESCRIPTION
## Summary
- update the dasel converter to use the dasel v3 CLI (`--var ... --out ...`) instead of removed `--file/--read/--write` flags
- close the child stdin pipe after spawning dasel so the v3 process does not wait for input under Bun
- add unit coverage for the generated v3 arguments and stdin handling

Fixes #579.

## Tests
- `PATH=/tmp/oss-pr-pipeline/convertx-579-tools/bin:$PATH bun test tests/converters/dasel.test.ts`
- real dasel v3.11.2 YAML→JSON smoke test through `convert()`
- `bun run lint:tsc`
- `bun run lint:prettier`
- `git diff --check`
- `PATH=/tmp/oss-pr-pipeline/convertx-579-tools/bin:$PATH bun test`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch `dasel` converter to v3 CLI flags (`--var ... --out ... $data`) and close stdin so v3 doesn't wait under Bun, fixing #579. Adds unit tests for argument generation and stdin handling.

<sup>Written for commit 87ef3a09cad2d4e1c4aad3eabe7ee4fc90d8ff0a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/C4illin/ConvertX/pull/591?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

