### PR TITLE
fix(imagemagick): handle multi-page PDF outputs and improve rasterization quality

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "convertx-frontend",

--- a/src/converters/imagemagick.ts
+++ b/src/converters/imagemagick.ts
@@ -461,6 +461,11 @@ export function convert(
     }
   }
 
+  // Increase rasterization quality for PDF input
+  if (fileType === "pdf") {
+    inputArgs.push("-density", "300");
+  }
+
   // Handle EMF files specifically to avoid LibreOffice delegate issues
   if (fileType === "emf") {
     // Use direct conversion without delegates for EMF files

--- a/src/converters/main.ts
+++ b/src/converters/main.ts
@@ -1,5 +1,7 @@
 import { Cookie } from "elysia";
 import db from "../db/db";
+import fs from "node:fs";
+import path from "node:path";
 import { MAX_CONVERT_PROCESS } from "../helpers/env";
 import { normalizeFiletype, normalizeOutputFiletype } from "../helpers/normalizeFiletype";
 import { convert as convertassimp, properties as propertiesassimp } from "./assimp";
@@ -182,7 +184,30 @@ export async function handleConvert(
           mainConverter(filePath, fileType, convertTo, targetPath, {}, converterName)
             .then((r) => {
               if (jobId.value) {
-                query.run(jobId.value, fileName, newFileName, r);
+                const dir = path.dirname(targetPath);
+                const parsed = path.parse(targetPath);
+
+                const outputFiles = fs
+                  .readdirSync(dir)
+                  .filter((f) => {
+                    if (f === parsed.base) {
+                      return true;
+                    }
+
+                    return (
+                      f.startsWith(`${parsed.name}-`) &&
+                      f.endsWith(parsed.ext)
+                    );
+                  })
+                  .sort();
+
+                if (outputFiles.length > 0) {
+                  for (const outputFile of outputFiles) {
+                    query.run(jobId.value, fileName, outputFile, r);
+                  }
+                } else {
+                  query.run(jobId.value, fileName, newFileName, r);
+                }
               }
               resolve(r);
             })

--- a/src/converters/main.ts
+++ b/src/converters/main.ts
@@ -196,10 +196,11 @@ export async function handleConvert(
 
                     return (
                       f.startsWith(`${parsed.name}-`) &&
-                      f.endsWith(parsed.ext)
+                      f.endsWith(parsed.ext) &&
+                      /^\d+$/.test(f.slice(parsed.name.length + 1, -parsed.ext.length))
                     );
                   })
-                  .sort();
+                  .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
 
                 if (outputFiles.length > 0) {
                   for (const outputFile of outputFiles) {


### PR DESCRIPTION
## Summary

Fix ImageMagick multi-page PDF conversions by storing the actual generated output filenames instead of assuming a single output file.

ImageMagick generates numbered output files for multi-page PDFs (e.g. `filename-0.png`, `filename-1.png`), but only `filename.png` was stored in the database. As a result, the View and Download actions attempted to access a file that did not exist.

Also increase PDF rasterization density to 300 DPI to improve PDF-to-image conversion quality.

## Changes

- Detect generated output files after conversion.
- Store all generated output filenames in the `file_names` table.
- Preserve existing behavior for single-output conversions.
- Increase PDF rasterization density to 300 DPI for improved image quality.

## Validation

- Converted a 2-page PDF to PNG using ImageMagick.
- Verified that all generated output files are stored in the `file_names` table.
- Verified that View and Download work correctly for each generated output file.
- Verified that PDF-to-PNG output quality is improved with 300 DPI.

Closes #541
Closes #340


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix multi-page PDF conversions by storing every generated ImageMagick output and raising PDF rasterization to 300 DPI. View and Download links now work per page, and PDF previews are sharper.

- **Bug Fixes**
  - Discover and numerically sort numbered outputs (`filename-0.png`, `filename-1.png`) instead of assuming a single file.
  - Fall back to the original single-file behavior when no numbered outputs are produced.

<sup>Written for commit aef3e8097a03b43829e5a21110fd9a15938bfa88. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/C4illin/ConvertX/pull/593?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



