### PR TITLE
docs: add Zenith Hosting deploy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,14 @@ Then visit `http://localhost:3000` in your browser and create your account. Don'
 
 If you get unable to open database file run `chown -R $USER:$USER path` on the path you choose.
 
+### Managed hosting
+
+If you'd rather not run a server yourself:
+
+[![Deploy with Zenith](https://cdn.zenith.hosting/buttons/deploy-with-zenith.svg)](https://zenith.hosting/host/convertx)
+
+One-click managed ConvertX: storage, backups and a free subdomain included. A share of every subscription goes back to ConvertX.
+
 ### Environment variables
 
 All are optional, JWT_SECRET is recommended to be set.


### PR DESCRIPTION
hey, i work on Zenith Hosting, a startup doing one-click hosting for open source apps. we added ConvertX to our marketplace, so this PR adds a small "Deploy with Zenith" badge under Deployment (links to https://zenith.hosting/host/convertx).

we share a cut of revenue with the projects we host. happy to explain if you're curious: hello@zenith.hosting

README-only, one new subsection between the docker instructions and the environment variables table. no code touched, and the self-hosting instructions stay exactly where they are.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a Managed hosting section to README with a “Deploy with Zenith” badge linking to https://zenith.hosting/host/convertx for one-click ConvertX hosting. Placed between the Docker instructions and the Environment variables section; self-hosting docs unchanged and no code changes.

<sup>Written for commit ef76b48d331308ec3f3cf3352c53960a8fc41e5a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/C4illin/ConvertX/pull/597?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

