### PR TITLE
feat: trusted-header (reverse-proxy) SSO auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ All are optional, JWT_SECRET is recommended to be set.
 | ACCOUNT_REGISTRATION         | false                                              | Allow users to register accounts                                                                                                                              |
 | HTTP_ALLOWED                 | false                                              | Allow HTTP connections, only set this to true locally                                                                                                         |
 | ALLOW_UNAUTHENTICATED        | false                                              | Allow unauthenticated users to use the service, only set this to true locally                                                                                 |
+| HTTP_REMOTE_USER_ENABLED     | false                                              | Trust a reverse proxy to authenticate users and sign them in from a header (SSO). Only enable behind a proxy that strips the header — see below.               |
+| HTTP_REMOTE_USER_HEADER      | Remote-User                                        | Header the trusted proxy passes the authenticated identity in (e.g. `X-authentik-email`, `X-Forwarded-Email`). Case-insensitive.                              |
 | AUTO_DELETE_EVERY_N_HOURS    | 24                                                 | Checks every n hours for files older then n hours and deletes them, set to 0 to disable                                                                       |
 | WEBROOT                      |                                                    | The address to the root path setting this to "/convert" will serve the website on "example.com/convert/"                                                      |
 | FFMPEG_ARGS                  |                                                    | Arguments to pass to the input file of ffmpeg, e.g. `-hwaccel vaapi`. See https://github.com/C4illin/ConvertX/issues/190 for more info about hw-acceleration. |
@@ -101,6 +103,20 @@ All are optional, JWT_SECRET is recommended to be set.
 | LANGUAGE                     | en                                                 | Language to format date strings in, specified as a [BCP 47 language tag](https://en.wikipedia.org/wiki/IETF_language_tag)                                     |
 | UNAUTHENTICATED_USER_SHARING | false                                              | Shares conversion history between all unauthenticated users                                                                                                   |
 | MAX_CONVERT_PROCESS          | 0                                                  | Maximum number of concurrent conversion processes allowed. Set to 0 for unlimited.                                                                            |
+
+### Reverse proxy / SSO (trusted header)
+
+If you already run a reverse proxy that authenticates users — [Authentik](https://goauthentik.io/) (forward-auth outpost), [Authelia](https://www.authelia.com/), [oauth2-proxy](https://oauth2-proxy.github.io/oauth2-proxy/), Cloudflare Access, etc. — ConvertX can trust it instead of asking users to log in a second time. Set `HTTP_REMOTE_USER_ENABLED=true` and point `HTTP_REMOTE_USER_HEADER` at the header your proxy injects the authenticated identity in. On each request ConvertX reads that header, looks up the matching account (creating it on first sight), and signs the user in — so users go straight from your SSO to the app. The normal login/registration form still works for anyone reaching ConvertX without the header.
+
+```yml
+# behind an Authentik forward-auth outpost:
+environment:
+  - HTTP_REMOTE_USER_ENABLED=true
+  - HTTP_REMOTE_USER_HEADER=X-authentik-email # or X-authentik-username
+```
+
+> [!WARNING]
+> Only enable this behind a trusted reverse proxy, and make sure that proxy **strips any client-supplied copy of `HTTP_REMOTE_USER_HEADER`** before it sets its own. If ConvertX is reachable by clients directly (no proxy in front), anyone can send the header themselves and impersonate any user — so never enable it in that case. This is the same trade-off as other self-hosted apps' remote-user auth (e.g. paperless-ngx).
 
 ### Docker images
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ All are optional, JWT_SECRET is recommended to be set.
 | ACCOUNT_REGISTRATION         | false                                              | Allow users to register accounts                                                                                                                              |
 | HTTP_ALLOWED                 | false                                              | Allow HTTP connections, only set this to true locally                                                                                                         |
 | ALLOW_UNAUTHENTICATED        | false                                              | Allow unauthenticated users to use the service, only set this to true locally                                                                                 |
-| HTTP_REMOTE_USER_ENABLED     | false                                              | Trust a reverse proxy to authenticate users and sign them in from a header (SSO). Only enable behind a proxy that strips the header — see below.               |
+| HTTP_REMOTE_USER_ENABLED     | false                                              | Trust a reverse proxy to authenticate users and sign them in from a header (SSO). Only enable behind a proxy that strips the header — see below.              |
 | HTTP_REMOTE_USER_HEADER      | Remote-User                                        | Header the trusted proxy passes the authenticated identity in (e.g. `X-authentik-email`, `X-Forwarded-Email`). Case-insensitive.                              |
 | AUTO_DELETE_EVERY_N_HOURS    | 24                                                 | Checks every n hours for files older then n hours and deletes them, set to 0 to disable                                                                       |
 | WEBROOT                      |                                                    | The address to the root path setting this to "/convert" will serve the website on "example.com/convert/"                                                      |
@@ -107,6 +107,8 @@ All are optional, JWT_SECRET is recommended to be set.
 ### Reverse proxy / SSO (trusted header)
 
 If you already run a reverse proxy that authenticates users — [Authentik](https://goauthentik.io/) (forward-auth outpost), [Authelia](https://www.authelia.com/), [oauth2-proxy](https://oauth2-proxy.github.io/oauth2-proxy/), Cloudflare Access, etc. — ConvertX can trust it instead of asking users to log in a second time. Set `HTTP_REMOTE_USER_ENABLED=true` and point `HTTP_REMOTE_USER_HEADER` at the header your proxy injects the authenticated identity in. On each request ConvertX reads that header, looks up the matching account (creating it on first sight), and signs the user in — so users go straight from your SSO to the app. The normal login/registration form still works for anyone reaching ConvertX without the header.
+
+Logout is handled by your proxy/identity provider: because the header is present on every proxied request, ConvertX's own logout would immediately re-authenticate the user from it. Point your users at the proxy's logout (e.g. Authentik's end-session endpoint) to sign out.
 
 ```yml
 # behind an Authentik forward-auth outpost:

--- a/src/helpers/env.ts
+++ b/src/helpers/env.ts
@@ -24,4 +24,24 @@ export const MAX_CONVERT_PROCESS =
 export const UNAUTHENTICATED_USER_SHARING =
   process.env.UNAUTHENTICATED_USER_SHARING?.toLowerCase() === "true" || false;
 
+// Trusted-header (reverse-proxy) SSO. When enabled, a reverse proxy in front of
+// ConvertX (Authentik, Authelia, oauth2-proxy, Cloudflare Access, ...) performs
+// authentication and passes the authenticated identity in a header. ConvertX
+// trusts that header, auto-provisions/looks up the matching account and signs
+// the user in — no second ConvertX login.
+//
+// SECURITY: only enable behind a proxy that STRIPS any client-supplied copy of
+// HTTP_REMOTE_USER_HEADER before injecting its own. Without a trusted proxy in
+// front, a client can send the header directly and impersonate any user. Never
+// enable this when ConvertX is reachable by clients directly. See the README.
+export const HTTP_REMOTE_USER_ENABLED =
+  process.env.HTTP_REMOTE_USER_ENABLED?.toLowerCase() === "true" || false;
+
+// Name of the header the trusted proxy injects the authenticated identity in.
+// Default "Remote-User" (the common convention). For an Authentik forward-auth
+// outpost set this to "X-authentik-email" (or "X-authentik-username"); for
+// oauth2-proxy "X-Forwarded-Email"; for Authelia "Remote-User". Header lookup
+// is case-insensitive.
+export const HTTP_REMOTE_USER_HEADER = process.env.HTTP_REMOTE_USER_HEADER || "Remote-User";
+
 export const TIMEZONE = process.env.TZ || undefined;

--- a/src/pages/root.tsx
+++ b/src/pages/root.tsx
@@ -21,8 +21,10 @@ export const root = new Elysia().use(userService).get(
   async ({ request, jwt, redirect, cookie: { auth, jobId } }) => {
     // Trusted-header SSO: if a reverse proxy already authenticated the request,
     // establish the ConvertX session here — before any auth redirect — so the
-    // user lands straight on the app with no second login.
-    if (!auth?.value) {
+    // user lands straight on the app with no second login. Skipped under
+    // ALLOW_UNAUTHENTICATED (mutually exclusive: that mode issues its own
+    // ephemeral session below and would just overwrite this one).
+    if (!ALLOW_UNAUTHENTICATED && !auth?.value) {
       const ssoToken = await trustedHeaderToken(request, jwt);
       if (ssoToken && auth) {
         auth.set({

--- a/src/pages/root.tsx
+++ b/src/pages/root.tsx
@@ -14,11 +14,27 @@ import {
   UNAUTHENTICATED_USER_SHARING,
   WEBROOT,
 } from "../helpers/env";
-import { FIRST_RUN, userService } from "./user";
+import { FIRST_RUN, trustedHeaderToken, userService } from "./user";
 
 export const root = new Elysia().use(userService).get(
   "/",
-  async ({ jwt, redirect, cookie: { auth, jobId } }) => {
+  async ({ request, jwt, redirect, cookie: { auth, jobId } }) => {
+    // Trusted-header SSO: if a reverse proxy already authenticated the request,
+    // establish the ConvertX session here — before any auth redirect — so the
+    // user lands straight on the app with no second login.
+    if (!auth?.value) {
+      const ssoToken = await trustedHeaderToken(request, jwt);
+      if (ssoToken && auth) {
+        auth.set({
+          value: ssoToken,
+          httpOnly: true,
+          secure: !HTTP_ALLOWED,
+          maxAge: 60 * 60 * 24 * 7,
+          sameSite: "strict",
+        });
+      }
+    }
+
     if (!ALLOW_UNAUTHENTICATED) {
       if (FIRST_RUN) {
         return redirect(`${WEBROOT}/setup`, 302);

--- a/src/pages/root.tsx
+++ b/src/pages/root.tsx
@@ -14,26 +14,29 @@ import {
   UNAUTHENTICATED_USER_SHARING,
   WEBROOT,
 } from "../helpers/env";
-import { FIRST_RUN, trustedHeaderToken, userService } from "./user";
+import {
+  EPHEMERAL_SESSION_MAX_AGE,
+  FIRST_RUN,
+  setSessionCookie,
+  trustedHeaderToken,
+  userService,
+} from "./user";
 
 export const root = new Elysia().use(userService).get(
   "/",
   async ({ request, jwt, redirect, cookie: { auth, jobId } }) => {
     // Trusted-header SSO: if a reverse proxy already authenticated the request,
     // establish the ConvertX session here — before any auth redirect — so the
-    // user lands straight on the app with no second login. Skipped under
+    // user lands straight on the app with no second login. Run this on every
+    // request (not only when no cookie is present): the proxy is authoritative
+    // in SSO mode, so a changed header must be able to switch the session even
+    // when a stale cookie for a previous user is still set. Skipped under
     // ALLOW_UNAUTHENTICATED (mutually exclusive: that mode issues its own
-    // ephemeral session below and would just overwrite this one).
-    if (!ALLOW_UNAUTHENTICATED && !auth?.value) {
+    // ephemeral session below, and trustedHeaderToken itself returns null there).
+    if (!ALLOW_UNAUTHENTICATED) {
       const ssoToken = await trustedHeaderToken(request, jwt);
       if (ssoToken && auth) {
-        auth.set({
-          value: ssoToken,
-          httpOnly: true,
-          secure: !HTTP_ALLOWED,
-          maxAge: 60 * 60 * 24 * 7,
-          sameSite: "strict",
-        });
+        setSessionCookie(auth, ssoToken);
       }
     }
 
@@ -67,13 +70,7 @@ export const root = new Elysia().use(userService).get(
       }
 
       // set cookie
-      auth.set({
-        value: accessToken,
-        httpOnly: true,
-        secure: !HTTP_ALLOWED,
-        maxAge: 24 * 60 * 60,
-        sameSite: "strict",
-      });
+      setSessionCookie(auth, accessToken, EPHEMERAL_SESSION_MAX_AGE);
     } else if (auth?.value) {
       user = await jwt.verify(auth.value);
 

--- a/src/pages/user.tsx
+++ b/src/pages/user.tsx
@@ -10,10 +10,59 @@ import {
   ALLOW_UNAUTHENTICATED,
   HIDE_HISTORY,
   HTTP_ALLOWED,
+  HTTP_REMOTE_USER_ENABLED,
+  HTTP_REMOTE_USER_HEADER,
   WEBROOT,
 } from "../helpers/env";
 
 export let FIRST_RUN = db.query("SELECT * FROM users").get() === null || false;
+
+/**
+ * Trusted-header (reverse-proxy) SSO.
+ *
+ * When HTTP_REMOTE_USER_ENABLED, a trusted reverse proxy in front of ConvertX
+ * has already authenticated the request and passes the user's identity in
+ * HTTP_REMOTE_USER_HEADER. We look up the local account for that identity —
+ * auto-provisioning it on first sight — and return a freshly signed session
+ * token so the caller can set the auth cookie. No second ConvertX login.
+ *
+ * Returns the signed JWT string if a session was established from a trusted
+ * header, otherwise null (feature disabled, header absent, or lookup failed).
+ *
+ * SECURITY: callers only run this behind a proxy that strips any client-supplied
+ * copy of the header. See the env.ts note and the README.
+ */
+export async function trustedHeaderToken(
+  request: Request,
+  jwt: { sign: (payload: { id: string }) => Promise<string> },
+): Promise<string | null> {
+  if (!HTTP_REMOTE_USER_ENABLED) {
+    return null;
+  }
+
+  const identity = request.headers.get(HTTP_REMOTE_USER_HEADER)?.trim();
+  if (!identity) {
+    return null;
+  }
+
+  let user = db.query("SELECT * FROM users WHERE email = ?").as(User).get(identity);
+  if (!user) {
+    // Auto-provision. The local password is a random value the user never uses
+    // and cannot know — they always authenticate through the trusted proxy.
+    const savedPassword = await Bun.password.hash(randomUUID());
+    db.query("INSERT INTO users (email, password) VALUES (?, ?)").run(identity, savedPassword);
+    user = db.query("SELECT * FROM users WHERE email = ?").as(User).get(identity);
+    if (FIRST_RUN) {
+      FIRST_RUN = false;
+    }
+  }
+
+  if (!user) {
+    return null;
+  }
+
+  return jwt.sign({ id: String(user.id) });
+}
 
 export const userService = new Elysia({ name: "user/service" })
   .use(
@@ -65,7 +114,21 @@ export const userService = new Elysia({ name: "user/service" })
 
 export const user = new Elysia()
   .use(userService)
-  .get("/setup", ({ redirect }) => {
+  .get("/setup", async ({ request, jwt, redirect, cookie: { auth } }) => {
+    // Trusted-header SSO: the proxy already authenticated the (first) user —
+    // provision them as the initial account and sign them straight in.
+    const ssoToken = await trustedHeaderToken(request, jwt);
+    if (ssoToken && auth) {
+      auth.set({
+        value: ssoToken,
+        httpOnly: true,
+        secure: !HTTP_ALLOWED,
+        maxAge: 60 * 60 * 24 * 7,
+        sameSite: "strict",
+      });
+      return redirect(`${WEBROOT}/`, 302);
+    }
+
     if (!FIRST_RUN) {
       return redirect(`${WEBROOT}/login`, 302);
     }
@@ -237,7 +300,21 @@ export const user = new Elysia()
   )
   .get(
     "/login",
-    async ({ jwt, redirect, cookie: { auth } }) => {
+    async ({ request, jwt, redirect, cookie: { auth } }) => {
+      // Trusted-header SSO: if the proxy already authenticated the request,
+      // establish the session and skip the login form entirely.
+      const ssoToken = await trustedHeaderToken(request, jwt);
+      if (ssoToken && auth) {
+        auth.set({
+          value: ssoToken,
+          httpOnly: true,
+          secure: !HTTP_ALLOWED,
+          maxAge: 60 * 60 * 24 * 7,
+          sameSite: "strict",
+        });
+        return redirect(`${WEBROOT}/`, 302);
+      }
+
       if (FIRST_RUN) {
         return redirect(`${WEBROOT}/setup`, 302);
       }

--- a/src/pages/user.tsx
+++ b/src/pages/user.tsx
@@ -17,6 +17,40 @@ import {
 
 export let FIRST_RUN = db.query("SELECT * FROM users").get() === null || false;
 
+/** Standard session lifetime (matches the JWT `exp` of 7 days). */
+export const SESSION_MAX_AGE = 60 * 60 * 24 * 7;
+/** Shorter lifetime for the ephemeral ALLOW_UNAUTHENTICATED session. */
+export const EPHEMERAL_SESSION_MAX_AGE = 24 * 60 * 60;
+
+/**
+ * Set the auth session cookie with the project's hardened defaults
+ * (httpOnly, secure unless HTTP_ALLOWED, SameSite=strict). Centralised here so
+ * the security-sensitive cookie policy lives in exactly one place — every
+ * caller (register/login, ALLOW_UNAUTHENTICATED, and trusted-header SSO) sets
+ * it identically, and a future hardening change only has to be made once.
+ */
+export function setSessionCookie(
+  auth: {
+    set: (options: {
+      value: string;
+      httpOnly: boolean;
+      secure: boolean;
+      maxAge: number;
+      sameSite: "strict";
+    }) => void;
+  },
+  value: string,
+  maxAge: number = SESSION_MAX_AGE,
+): void {
+  auth.set({
+    value,
+    httpOnly: true,
+    secure: !HTTP_ALLOWED,
+    maxAge,
+    sameSite: "strict",
+  });
+}
+
 /**
  * Trusted-header (reverse-proxy) SSO.
  *
@@ -36,7 +70,11 @@ export async function trustedHeaderToken(
   request: Request,
   jwt: { sign: (payload: { id: string }) => Promise<string> },
 ): Promise<string | null> {
-  if (!HTTP_REMOTE_USER_ENABLED) {
+  // ALLOW_UNAUTHENTICATED and trusted-header SSO are mutually exclusive modes.
+  // Guard here (rather than at each call site) so every caller — /, /setup and
+  // /login — skips auto-provisioning and SSO sessions when unauthenticated mode
+  // is on, regardless of whether the proxy still supplies the header.
+  if (!HTTP_REMOTE_USER_ENABLED || ALLOW_UNAUTHENTICATED) {
     return null;
   }
 
@@ -119,13 +157,7 @@ export const user = new Elysia()
     // provision them as the initial account and sign them straight in.
     const ssoToken = await trustedHeaderToken(request, jwt);
     if (ssoToken && auth) {
-      auth.set({
-        value: ssoToken,
-        httpOnly: true,
-        secure: !HTTP_ALLOWED,
-        maxAge: 60 * 60 * 24 * 7,
-        sameSite: "strict",
-      });
+      setSessionCookie(auth, ssoToken);
       return redirect(`${WEBROOT}/`, 302);
     }
 
@@ -286,13 +318,7 @@ export const user = new Elysia()
       }
 
       // set cookie
-      auth.set({
-        value: accessToken,
-        httpOnly: true,
-        secure: !HTTP_ALLOWED,
-        maxAge: 60 * 60 * 24 * 7,
-        sameSite: "strict",
-      });
+      setSessionCookie(auth, accessToken);
 
       return redirect(`${WEBROOT}/`, 302);
     },
@@ -305,13 +331,7 @@ export const user = new Elysia()
       // establish the session and skip the login form entirely.
       const ssoToken = await trustedHeaderToken(request, jwt);
       if (ssoToken && auth) {
-        auth.set({
-          value: ssoToken,
-          httpOnly: true,
-          secure: !HTTP_ALLOWED,
-          maxAge: 60 * 60 * 24 * 7,
-          sameSite: "strict",
-        });
+        setSessionCookie(auth, ssoToken);
         return redirect(`${WEBROOT}/`, 302);
       }
 
@@ -425,13 +445,7 @@ export const user = new Elysia()
       }
 
       // set cookie
-      auth.set({
-        value: accessToken,
-        httpOnly: true,
-        secure: !HTTP_ALLOWED,
-        maxAge: 60 * 60 * 24 * 7,
-        sameSite: "strict",
-      });
+      setSessionCookie(auth, accessToken);
 
       return redirect(`${WEBROOT}/`, 302);
     },


### PR DESCRIPTION
## What

Adds optional **trusted-header (reverse-proxy) SSO**. When enabled, a reverse proxy that already authenticates users — Authentik (forward-auth outpost), Authelia, oauth2-proxy, Cloudflare Access, etc. — can sign users into ConvertX by passing the authenticated identity in a header, so there's no second ConvertX login.

Closes #146.

## Why

ConvertX currently has only its own local login. When it runs behind a forward-auth proxy, users have to authenticate twice — once at the proxy, once at ConvertX. This is the pattern paperless-ngx solves with `PAPERLESS_ENABLE_HTTP_REMOTE_USER`; this PR brings the same lightweight approach to ConvertX (no OAuth client/dependency — the proxy is already doing the auth).

## How

Two new (optional, off-by-default) env vars:

| Name | Default | Description |
| --- | --- | --- |
| `HTTP_REMOTE_USER_ENABLED` | `false` | Trust a reverse proxy to authenticate users and sign them in from a header. |
| `HTTP_REMOTE_USER_HEADER` | `Remote-User` | Header the proxy injects the identity in (e.g. `X-authentik-email`, `X-Forwarded-Email`). Case-insensitive. |

When enabled, the `/`, `/login` and `/setup` handlers read the configured header; the matching account is looked up and **auto-provisioned on first sight** (the local password is a random unused value), then a normal session cookie is issued. The built-in login/registration form still works for requests without the header, so nothing changes when the feature is off.

## Security

Documented in `env.ts` and the README, mirroring paperless-ngx's guidance: only enable behind a proxy that **strips any client-supplied copy of the header** before setting its own. Off by default; the header logic never runs unless `HTTP_REMOTE_USER_ENABLED=true`. It only establishes a session through the three GET handlers above (it doesn't add header-auth to any upload/convert/download route), so there's no bypass of the existing cookie/JWT checks.

## Notes / scope

- Auto-provisioning uses the existing `users` table and the same non-atomic "check then insert" as the current `/register` handler (the `email` column isn't `UNIQUE`), so behavior is consistent with what's already there; I left the schema untouched.
- Logout is proxy/IdP-managed under this mode (the header is present on every proxied request, so ConvertX's own logout would immediately re-authenticate) — noted in the README.
- `ALLOW_UNAUTHENTICATED` and this mode are mutually exclusive; the trusted-header path is skipped when `ALLOW_UNAUTHENTICATED` is set.

## Testing

`bun run lint` passes (tsc + knip + eslint + prettier). Verified behaviorally against a running instance:

- `/setup` + header on a fresh DB → provisions the first account, sets the cookie, 302 to `/`.
- `/login` + header → auto-provisions/logs in, 302 to `/` (no second login).
- `/` + header → session established in-request, app renders (no redirect loop).
- `/login` without the header → normal login form still served.
- feature disabled + header present → header ignored (no bypass).
- `ALLOW_UNAUTHENTICATED=true` + header → header path skipped (no stray provisioning).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds optional trusted-header SSO for reverse-proxy setups. Users authenticated by a proxy (Authentik, Authelia, `oauth2-proxy`, Cloudflare Access) are signed into ConvertX without a second login. It runs on every request and switches sessions if the proxy identity changes.

- **New Features**
  - `HTTP_REMOTE_USER_ENABLED` and `HTTP_REMOTE_USER_HEADER` env vars.
  - Auto-provisions users and issues a normal session on `/`, `/login`, and `/setup` (runs each request; switches if the header identity changes).
  - Disabled by default; skipped when `ALLOW_UNAUTHENTICATED=true`.
  - Fallback to built-in login/registration when the header is absent.

- **Migration**
  - Enable `HTTP_REMOTE_USER_ENABLED` and set `HTTP_REMOTE_USER_HEADER` to the proxy’s identity header.
  - Ensure the proxy strips any client-supplied copy of that header; logout is handled by the proxy/IdP.

<sup>Written for commit 03d88063317e843a11a725be628ea9734c8bf920. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/C4illin/ConvertX/pull/600?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

