### PR TITLE
ci: change autolabeler to a custom built

### DIFF
--- a/.github/workflows/conventional-label.yml
+++ b/.github/workflows/conventional-label.yml
@@ -1,23 +1,26 @@
+name: autolabel
 on:
-  pull_request_target:
-    types: [opened, edited]
-name: conventional-release-labels
+  pull_request:
+    types: [opened, edited, labeled, unlabeled]
+
 permissions:
-  contents: read
   pull-requests: write
+
 jobs:
   label:
     runs-on: ubuntu-latest
     steps:
-      - uses: bcoe/conventional-release-labels@v1
+      - uses: c4illin/autolabel@v1
         with:
           type_labels: |
-            {
-              "feat": "Feature",
-              "fix": "Fix",
-              "breaking": "Breaking",
-              "chore": "Chore",
-              "docs": "Docs",
-              "test": "Test",
-              "ci": "CI"
-            }
+            feat: Feature
+            fix: Fix
+            docs: Docs
+            style: Style
+            refactor: Refactor
+            perf: Performance
+            test: Test
+            build: Build
+            ci: CI
+            revert: Revert
+            breaking: Breaking

--- a/.github/workflows/conventional-label.yml
+++ b/.github/workflows/conventional-label.yml
@@ -1,7 +1,7 @@
 name: autolabel
 on:
-  pull_request:
-    types: [opened, edited, labeled, unlabeled]
+  pull_request_target:
+    types: [opened, edited]
 
 permissions:
   pull-requests: write

--- a/.github/workflows/conventional-label.yml
+++ b/.github/workflows/conventional-label.yml
@@ -10,7 +10,7 @@ jobs:
   label:
     runs-on: ubuntu-latest
     steps:
-      - uses: c4illin/autolabel@v1
+      - uses: c4illin/autolabel@main
         with:
           type_labels: |
             feat: Feature


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch to a custom PR auto-labeler using `c4illin/autolabel@main` for better control and broader label coverage. Simplifies permissions and updates the workflow name and label mappings.

- **Refactors**
  - Replace `bcoe/conventional-release-labels@v1` with `c4illin/autolabel@main`.
  - Rename workflow to "autolabel" and keep `pull_request_target` on `opened` and `edited`.
  - Restrict permissions to `pull-requests: write` only.
  - Use YAML mappings and expand labels: Feature, Fix, Docs, Style, Refactor, Performance, Test, Build, CI, Revert, Breaking.

<sup>Written for commit e06bd77e24e5060de1dfeae8859262c8e4bebecf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/C4illin/ConvertX/pull/603?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

