### PR TITLE
fix: version printing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,6 +62,7 @@ RUN apt-get update && apt-get install -y \
   libreoffice \
   libva2 \
   libvips-tools \
+  libemail-address-perl \
   libemail-outlook-message-perl \
   lmodern \
   mupdf-tools \

--- a/knip.json
+++ b/knip.json
@@ -18,7 +18,7 @@
     "heif-info",
     "potrace",
     "soffice",
-    "msgconvert"
+    "perl"
   ],
   "tailwind": {
     "entry": ["src/main.css"]

--- a/src/helpers/printVersions.ts
+++ b/src/helpers/printVersions.ts
@@ -100,7 +100,7 @@ if (process.env.NODE_ENV === "production") {
     }
 
     if (stdout) {
-      console.log(`dasel v${stdout.split("\n")[0]}`);
+      console.log(`dasel ${stdout.split("\n")[0]}`);
     }
   });
 

--- a/src/helpers/printVersions.ts
+++ b/src/helpers/printVersions.ts
@@ -121,7 +121,7 @@ if (process.env.NODE_ENV === "production") {
     }
 
     if (stdout) {
-      const firstLines = (stdout || "").split("\n");
+      const firstLines = stdout.split("\n");
       console.log(`assimp ${firstLines[5] || firstLines[0] || ""}`);
     }
   });

--- a/src/helpers/printVersions.ts
+++ b/src/helpers/printVersions.ts
@@ -111,11 +111,7 @@ if (process.env.NODE_ENV === "production") {
     }
 
     if (stdout) {
-      // stdout may contain the command plus version (e.g. "resvg -V v1.0.0").
-      // Extract the last token and print it as version to avoid duplication.
-      const firstLine = (stdout || "").split("\n")[0] || "";
-      const lastToken = (firstLine.split(" ").filter(Boolean).pop() ?? "").toString();
-      console.log(`resvg ${lastToken}`);
+      console.log(`resvg v${stdout.split("\n")[0]}`);
     }
   });
 
@@ -125,13 +121,7 @@ if (process.env.NODE_ENV === "production") {
     }
 
     if (stdout) {
-      // assimp prints its version on a specific line in real output; if the
-      // expected line isn't present (e.g. in tests/mocks), fall back to the
-      // first non-empty line. Then extract the last token as version.
-      const lines = (stdout || "").split("\n").filter(Boolean);
-      const candidate = (lines[5] ?? lines[0] ?? "").toString();
-      const lastToken = (candidate.split(" ").filter(Boolean).pop() ?? "").toString();
-      console.log(`assimp ${lastToken}`);
+      console.log(`assimp ${stdout.split("\n")[5]}`);
     }
   });
 
@@ -191,12 +181,7 @@ if (process.env.NODE_ENV === "production") {
     }
 
     if (stdout) {
-      // stdout may include the command itself (e.g. "bun -v v1.0.0"). Extract
-      // the last token which should contain the version (possibly prefixed
-      // with 'v').
-      const firstLine = (stdout || "").split("\n")[0] || "";
-      const lastToken = (firstLine.split(" ").filter(Boolean).pop() ?? "").toString();
-      console.log(`Bun ${lastToken}`);
+      console.log(`Bun v${stdout.split("\n")[0]}`);
     }
   });
 }

--- a/src/helpers/printVersions.ts
+++ b/src/helpers/printVersions.ts
@@ -121,7 +121,8 @@ if (process.env.NODE_ENV === "production") {
     }
 
     if (stdout) {
-      console.log(`assimp ${stdout.split("\n")[5]}`);
+      const firstLines = (stdout || "").split("\n");
+      console.log(`assimp ${firstLines[5] || firstLines[0] || ""}`);
     }
   });
 

--- a/src/helpers/printVersions.ts
+++ b/src/helpers/printVersions.ts
@@ -8,6 +8,7 @@ if (process.env.NODE_ENV === "production") {
   readFile("/etc/os-release", "utf8", (error, stdout) => {
     if (error) {
       console.error("Not running on docker, this is not supported.");
+      return;
     }
 
     if (stdout) {
@@ -18,6 +19,7 @@ if (process.env.NODE_ENV === "production") {
   exec("pandoc -v", (error, stdout) => {
     if (error) {
       console.error("Pandoc is not installed.");
+      return;
     }
 
     if (stdout) {
@@ -28,6 +30,7 @@ if (process.env.NODE_ENV === "production") {
   exec("ffmpeg -version", (error, stdout) => {
     if (error) {
       console.error("FFmpeg is not installed.");
+      return;
     }
 
     if (stdout) {
@@ -38,6 +41,7 @@ if (process.env.NODE_ENV === "production") {
   exec("vips -v", (error, stdout) => {
     if (error) {
       console.error("Vips is not installed.");
+      return;
     }
 
     if (stdout) {
@@ -48,6 +52,7 @@ if (process.env.NODE_ENV === "production") {
   exec("magick --version", (error, stdout) => {
     if (error) {
       console.error("ImageMagick is not installed.");
+      return;
     }
 
     if (stdout) {
@@ -58,6 +63,7 @@ if (process.env.NODE_ENV === "production") {
   exec("gm version", (error, stdout) => {
     if (error) {
       console.error("GraphicsMagick is not installed.");
+      return;
     }
 
     if (stdout) {
@@ -68,6 +74,7 @@ if (process.env.NODE_ENV === "production") {
   exec("inkscape --version", (error, stdout) => {
     if (error) {
       console.error("Inkscape is not installed.");
+      return;
     }
 
     if (stdout) {
@@ -78,6 +85,7 @@ if (process.env.NODE_ENV === "production") {
   exec("djxl --version", (error, stdout) => {
     if (error) {
       console.error("libjxl-tools is not installed.");
+      return;
     }
 
     if (stdout) {
@@ -85,19 +93,21 @@ if (process.env.NODE_ENV === "production") {
     }
   });
 
-  exec("dasel --version", (error, stdout) => {
+  exec("dasel version", (error, stdout) => {
     if (error) {
       console.error("dasel is not installed.");
+      return;
     }
 
     if (stdout) {
-      console.log(stdout.split("\n")[0]);
+      console.log(`dasel v${stdout.split("\n")[0]}`);
     }
   });
 
   exec("xelatex -version", (error, stdout) => {
     if (error) {
       console.error("Tex Live with XeTeX is not installed.");
+      return;
     }
 
     if (stdout) {
@@ -108,6 +118,7 @@ if (process.env.NODE_ENV === "production") {
   exec("resvg -V", (error, stdout) => {
     if (error) {
       console.error("resvg is not installed");
+      return;
     }
 
     if (stdout) {
@@ -118,6 +129,7 @@ if (process.env.NODE_ENV === "production") {
   exec("assimp version", (error, stdout) => {
     if (error) {
       console.error("assimp is not installed");
+      return;
     }
 
     if (stdout) {
@@ -129,6 +141,7 @@ if (process.env.NODE_ENV === "production") {
   exec("ebook-convert --version", (error, stdout) => {
     if (error) {
       console.error("ebook-convert (calibre) is not installed");
+      return;
     }
 
     if (stdout) {
@@ -139,6 +152,7 @@ if (process.env.NODE_ENV === "production") {
   exec("heif-info -v", (error, stdout) => {
     if (error) {
       console.error("libheif is not installed");
+      return;
     }
 
     if (stdout) {
@@ -149,6 +163,7 @@ if (process.env.NODE_ENV === "production") {
   exec("potrace -v", (error, stdout) => {
     if (error) {
       console.error("potrace is not installed");
+      return;
     }
 
     if (stdout) {
@@ -159,6 +174,7 @@ if (process.env.NODE_ENV === "production") {
   exec("soffice --version", (error, stdout) => {
     if (error) {
       console.error("libreoffice is not installed");
+      return;
     }
 
     if (stdout) {
@@ -166,19 +182,25 @@ if (process.env.NODE_ENV === "production") {
     }
   });
 
-  exec("msgconvert --version", (error, stdout) => {
-    if (error) {
-      console.error("msgconvert (libemail-outlook-message-perl) is not installed");
-    }
+  // msgconvert has no version flag, so read the version of the perl module providing it
+  exec(
+    "perl -MEmail::Outlook::Message -e 'print $Email::Outlook::Message::VERSION'",
+    (error, stdout) => {
+      if (error) {
+        console.error("msgconvert (libemail-outlook-message-perl) is not installed");
+        return;
+      }
 
-    if (stdout) {
-      console.log(stdout.split("\n")[0]);
-    }
-  });
+      if (stdout) {
+        console.log(`msgconvert v${stdout.split("\n")[0]}`);
+      }
+    },
+  );
 
   exec("bun -v", (error, stdout) => {
     if (error) {
       console.error("Bun is not installed. wait what");
+      return;
     }
 
     if (stdout) {

--- a/tests/helpers/printVersions.test.ts
+++ b/tests/helpers/printVersions.test.ts
@@ -1,4 +1,4 @@
-import { test, expect, mock, spyOn, afterEach } from "bun:test";
+import { afterEach, expect, mock, spyOn, test } from "bun:test";
 import { exec } from "node:child_process";
 import { readFile } from "node:fs";
 
@@ -138,7 +138,7 @@ test("processes output parsing correctly and logs no errors in the success case"
   expect(consoleLogSpy).toHaveBeenCalledWith("ffmpeg -version v1.0.0");
   expect(consoleLogSpy).toHaveBeenCalledWith("resvg v1.0.0");
   expect(consoleLogSpy).toHaveBeenCalledWith("Bun v1.0.0");
-  expect(consoleLogSpy).toHaveBeenCalledWith("dasel v1.0.0");
+  expect(consoleLogSpy).toHaveBeenCalledWith("dasel 1.0.0");
   expect(consoleLogSpy).toHaveBeenCalledWith("msgconvert v1.0.0");
 
   // make sure that error paths have not been triggered

--- a/tests/helpers/printVersions.test.ts
+++ b/tests/helpers/printVersions.test.ts
@@ -27,7 +27,7 @@ mock.module("node:child_process", () => ({
 
     // assimp's real output is multi-line; the source reads line index 5.
     if (cmd.startsWith("assimp")) {
-      cb(null, "l1\nl2\nl3\nl4\nl5\nassimp v1.0.0\n");
+      cb(null, "l1\nl2\nl3\nl4\nl5\nVersion 1.0.0 (GIT commit abc123)\n");
       return;
     }
 

--- a/tests/helpers/printVersions.test.ts
+++ b/tests/helpers/printVersions.test.ts
@@ -5,18 +5,36 @@ import { readFile } from "node:fs";
 // mocks have to be defined before importing the module under test,
 // otherwise the real modules will be loaded first and the mocks won't take effect.
 mock.module("node:child_process", () => ({
-  // The mock checks the environment variable MOCK_EXEC_ERROR at call-time so
-  // individual tests can trigger error paths by setting that env before
-  // importing the module under test.
   exec: mock((cmd: string, cb: (error: Error | null, stdout: string) => void) => {
     const shouldError = (process.env.MOCK_EXEC_ERROR || "")
       .split(",")
       .some((p) => p && cmd.includes(p));
+
     if (shouldError) {
       cb(new Error(`${cmd} not found`), "");
-    } else {
-      cb(null, `${cmd} v1.0.0\n`);
+      return;
     }
+
+    // resvg, bun, and heif-info print just the bare version number —
+    // the source code itself prepends the tool name as a label.
+    if (cmd.startsWith("resvg") || cmd.startsWith("bun") || cmd.startsWith("heif-info")) {
+      cb(null, "1.0.0\n");
+      return;
+    }
+
+    // assimp's real output is multi-line; the source reads line index 5.
+    if (cmd.startsWith("assimp")) {
+      cb(null, "l1\nl2\nl3\nl4\nl5\nassimp v1.0.0\n");
+      return;
+    }
+
+    // magick prefixes its version line with "Version: ".
+    if (cmd.startsWith("magick")) {
+      cb(null, "Version: ImageMagick v1.0.0\n");
+      return;
+    }
+
+    cb(null, `${cmd} v1.0.0\n`);
   }),
 }));
 

--- a/tests/helpers/printVersions.test.ts
+++ b/tests/helpers/printVersions.test.ts
@@ -18,9 +18,15 @@ mock.module("node:child_process", () => ({
       return;
     }
 
-    // resvg, bun, and heif-info print just the bare version number —
-    // the source code itself prepends the tool name as a label.
-    if (cmd.startsWith("resvg") || cmd.startsWith("bun") || cmd.startsWith("heif-info")) {
+    // resvg, bun, heif-info, dasel, and the perl one-liner (msgconvert) print just
+    // the bare version number — the source code itself prepends the tool name as a label.
+    if (
+      cmd.startsWith("resvg") ||
+      cmd.startsWith("bun") ||
+      cmd.startsWith("heif-info") ||
+      cmd.startsWith("dasel") ||
+      cmd.startsWith("perl")
+    ) {
       cb(null, "1.0.0\n");
       return;
     }
@@ -100,8 +106,8 @@ test("prints system information and tool versions in production mode", async () 
 
 test("logs error paths when tools are missing", async () => {
   process.env.NODE_ENV = "production";
-  // Trigger a few error paths
-  process.env.MOCK_EXEC_ERROR = "pandoc,resvg,bun";
+  // Trigger a few error paths ("perl" is the msgconvert version lookup)
+  process.env.MOCK_EXEC_ERROR = "pandoc,resvg,bun,perl";
   consoleLogSpy = spyOn(console, "log");
   consoleErrorSpy = spyOn(console, "error");
 
@@ -112,6 +118,9 @@ test("logs error paths when tools are missing", async () => {
   expect(consoleErrorSpy).toHaveBeenCalledWith("Pandoc is not installed.");
   expect(consoleErrorSpy).toHaveBeenCalledWith("resvg is not installed");
   expect(consoleErrorSpy).toHaveBeenCalledWith("Bun is not installed. wait what");
+  expect(consoleErrorSpy).toHaveBeenCalledWith(
+    "msgconvert (libemail-outlook-message-perl) is not installed",
+  );
 });
 
 test("processes output parsing correctly and logs no errors in the success case", async () => {
@@ -129,6 +138,8 @@ test("processes output parsing correctly and logs no errors in the success case"
   expect(consoleLogSpy).toHaveBeenCalledWith("ffmpeg -version v1.0.0");
   expect(consoleLogSpy).toHaveBeenCalledWith("resvg v1.0.0");
   expect(consoleLogSpy).toHaveBeenCalledWith("Bun v1.0.0");
+  expect(consoleLogSpy).toHaveBeenCalledWith("dasel v1.0.0");
+  expect(consoleLogSpy).toHaveBeenCalledWith("msgconvert v1.0.0");
 
   // make sure that error paths have not been triggered
   expect(consoleErrorSpy).not.toHaveBeenCalled();

--- a/tests/helpers/printVersions.test.ts
+++ b/tests/helpers/printVersions.test.ts
@@ -5,6 +5,9 @@ import { readFile } from "node:fs";
 // mocks have to be defined before importing the module under test,
 // otherwise the real modules will be loaded first and the mocks won't take effect.
 mock.module("node:child_process", () => ({
+  // The mock checks the environment variable MOCK_EXEC_ERROR at call-time so
+  // individual tests can trigger error paths by setting that env before
+  // importing the module under test.
   exec: mock((cmd: string, cb: (error: Error | null, stdout: string) => void) => {
     const shouldError = (process.env.MOCK_EXEC_ERROR || "")
       .split(",")


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Restores predictable version logging and avoids misleading output when a tool is missing or the host isn’t Docker. Old behavior parsed ad‑hoc tokens; new behavior logs the first line verbatim for banner-style outputs and adds labeled lines where a tool prints only a bare version.

- `dasel`: call `dasel version`; print `dasel <version>` (no `v`).
- `msgconvert`: read version from Perl `Email::Outlook::Message` (`perl -MEmail::Outlook::Message -e 'print $Email::Outlook::Message::VERSION'`); print `msgconvert v<version>`; Docker installs `libemail-address-perl` alongside `libemail-outlook-message-perl`.
- `resvg` and `bun`: read the first stdout line and print `resvg v<line>` / `Bun v<line>`.
- `assimp`: log full line 6; fall back to line 1; drop token extraction.
- Add early returns after exec errors and `/etc/os-release` read errors to stop parsing when unsupported.
- Tests: realistic mocks for `resvg`, `bun`, `heif-info`, `dasel`, the Perl one‑liner, multi‑line `assimp`, and `magick`; include error‑path coverage for the Perl lookup and fix expectations.
- Knip: track `perl` instead of `msgconvert` in `knip.json` binaries.

<sup>Written for commit dcb9daa3c198773afb44472a7d413a617ca5ba7b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/C4illin/ConvertX/pull/606?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

