### PR TITLE
fix(ffmpeg): handle embedded cover art in audio conversions

### DIFF
--- a/src/converters/ffmpeg.ts
+++ b/src/converters/ffmpeg.ts
@@ -699,6 +699,15 @@ export async function convert(
   let extraArgs: string[] = [];
   let message = "Done";
 
+  const audioFormatsWithCover = ["m4a", "mp3", "flac", "ogg"];
+  const audioFormatsNoCover = ["wav", "aac"];
+
+  if (audioFormatsWithCover.includes(convertTo)) {
+    extraArgs.push("-c:v", "copy", "-disposition:v", "attached_pic");
+  } else if (audioFormatsNoCover.includes(convertTo)) {
+    extraArgs.push("-vn");
+  }
+
   if (convertTo === "ico") {
     // Make sure image is 256x256 or smaller
     extraArgs = [

--- a/src/converters/ffmpeg.ts
+++ b/src/converters/ffmpeg.ts
@@ -696,17 +696,11 @@ export async function convert(
   options?: unknown,
   execFile: ExecFileFn = execFileOriginal, // to make it mockable
 ): Promise<string> {
-  const extraArgs: string[] = [];
-  const message = "Done";
+  let extraArgs: string[] = [];
+  let message = "Done";
 
   const audioFormatsWithCover = ["m4a", "mp3", "flac", "ogg"];
   const audioFormatsNoCover = ["wav", "aac"];
-
-  if (audioFormatsWithCover.includes(convertTo)) {
-    extraArgs.push("-c:v", "copy", "-disposition:v", "attached_pic");
-  } else if (audioFormatsNoCover.includes(convertTo) || audioFormatsWithCover.includes(convertTo)) {
-    extraArgs.push("-vn");
-  }
 
   if (audioFormatsWithCover.includes(convertTo)) {
     extraArgs.push(
@@ -721,6 +715,15 @@ export async function convert(
     );
   } else if (audioFormatsNoCover.includes(convertTo)) {
     extraArgs.push("-vn");
+  }
+
+  if (convertTo === "ico") {
+    // Make sure image is 256x256 or smaller
+    extraArgs = [
+      "-filter:v",
+      "scale='min(256,iw)':min'(256,ih)':force_original_aspect_ratio=decrease",
+    ];
+    message = "Done: resized to 256x256";
   }
 
   if (convertTo.split(".").length > 1) {

--- a/src/converters/ffmpeg.ts
+++ b/src/converters/ffmpeg.ts
@@ -696,25 +696,31 @@ export async function convert(
   options?: unknown,
   execFile: ExecFileFn = execFileOriginal, // to make it mockable
 ): Promise<string> {
-  let extraArgs: string[] = [];
-  let message = "Done";
+  const extraArgs: string[] = [];
+  const message = "Done";
 
   const audioFormatsWithCover = ["m4a", "mp3", "flac", "ogg"];
   const audioFormatsNoCover = ["wav", "aac"];
 
   if (audioFormatsWithCover.includes(convertTo)) {
     extraArgs.push("-c:v", "copy", "-disposition:v", "attached_pic");
-  } else if (audioFormatsNoCover.includes(convertTo)) {
+  } else if (audioFormatsNoCover.includes(convertTo) || audioFormatsWithCover.includes(convertTo)) {
     extraArgs.push("-vn");
   }
 
-  if (convertTo === "ico") {
-    // Make sure image is 256x256 or smaller
-    extraArgs = [
-      "-filter:v",
-      "scale='min(256,iw)':min'(256,ih)':force_original_aspect_ratio=decrease",
-    ];
-    message = "Done: resized to 256x256";
+  if (audioFormatsWithCover.includes(convertTo)) {
+    extraArgs.push(
+      "-map",
+      "0:a",
+      "-map",
+      "0:v:disp:attached_pic?",
+      "-c:v",
+      "copy",
+      "-disposition:v",
+      "attached_pic",
+    );
+  } else if (audioFormatsNoCover.includes(convertTo)) {
+    extraArgs.push("-vn");
   }
 
   if (convertTo.split(".").length > 1) {


### PR DESCRIPTION
**Summary**
Fix FFmpeg audio conversions failing on files with embedded cover art by properly handling the image stream. Previously, FFmpeg treated embedded album art as a video stream and attempted to encode it as H.264, which caused incompatibility errors (e.g., `Could not find tag for codec h264`) when targeting audio containers like M4A.

**Changes**
- Detect target audio formats during FFmpeg conversion.
- Add `-c:v copy -disposition:v attached_pic` for target formats that support embedded images (`m4a`, `mp3`, `flac`, `ogg`). This preserves the cover art without re-encoding.
- Add `-vn` for target formats that do not support embedded images natively (`wav`, `aac`). This safely strips the image stream and allows the audio conversion to complete without errors.

**Validation**
- Converted an MP3 file with an embedded PNG cover to M4A. Verified that the conversion succeeds and the album art is preserved in the output file.
- Converted an MP3 file with an embedded PNG cover to WAV. Verified that the conversion succeeds without throwing H.264 encoding errors.

Closes #601

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes FFmpeg audio conversions failing on files with embedded cover art. Previously FFmpeg tried to re-encode the image as video (e.g., H.264) and errored; now we copy attached pictures for supported targets and strip video for others.

- In `src/converters/ffmpeg.ts`, add format gates: `m4a`, `mp3`, `flac`, `ogg` use `-map 0:a -map 0:v:disp:attached_pic? -c:v copy -disposition:v attached_pic`; `wav`, `aac` use `-vn`.
- `ico` resize logic remains intact and runs after cover handling.
- Validate: `mp3` → `m4a` (art preserved), `mp3` → `wav` (art removed), video → `m4a` (video dropped). No config or migration changes.

<sup>Written for commit 4c56c519ac9f7d581299d4f0d60baaf162f00588. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/C4illin/ConvertX/pull/607?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

