### PR TITLE
feat(soffice): add support for Excel and Calc spreadsheet conversions

### DIFF
--- a/src/converters/ffmpeg.ts
+++ b/src/converters/ffmpeg.ts
@@ -702,9 +702,41 @@ export async function convert(
   const audioFormatsWithCover = ["m4a", "mp3", "flac", "ogg"];
   const audioFormatsNoCover = ["wav", "aac"];
 
-  if (audioFormatsWithCover.includes(convertTo)) {
+  const audioInputFormats = [
+    "aac",
+    "ac3",
+    "ac4",
+    "aiff",
+    "alac",
+    "amr",
+    "ape",
+    "au",
+    "caf",
+    "dts",
+    "eac3",
+    "flac",
+    "m4a",
+    "m4b",
+    "mka",
+    "mp2",
+    "mp3",
+    "mpc",
+    "ogg",
+    "oga",
+    "opus",
+    "ra",
+    "voc",
+    "wav",
+    "wma",
+    "wv",
+  ];
+
+  if (
+    audioFormatsWithCover.includes(convertTo) &&
+    audioInputFormats.includes(fileType.toLowerCase())
+  ) {
     extraArgs.push("-c:v", "copy", "-disposition:v", "attached_pic");
-  } else if (audioFormatsNoCover.includes(convertTo)) {
+  } else if (audioFormatsNoCover.includes(convertTo) || audioFormatsWithCover.includes(convertTo)) {
     extraArgs.push("-vn");
   }
 

--- a/src/converters/ffmpeg.ts
+++ b/src/converters/ffmpeg.ts
@@ -699,6 +699,15 @@ export async function convert(
   let extraArgs: string[] = [];
   let message = "Done";
 
+  const audioFormatsWithCover = ["m4a", "mp3", "flac", "ogg"];
+  const audioFormatsNoCover = ["wav", "aac"];
+
+  if (audioFormatsWithCover.includes(convertTo)) {
+    extraArgs.push("-c:v", "copy", "-disposition:v", "attached_pic");
+  } else if (audioFormatsNoCover.includes(convertTo)) {
+    extraArgs.push("-vn");
+  }
+
   if (convertTo === "ico") {
     // Make sure image is 256x256 or smaller
     extraArgs = [

--- a/src/converters/ffmpeg.ts
+++ b/src/converters/ffmpeg.ts
@@ -699,47 +699,6 @@ export async function convert(
   let extraArgs: string[] = [];
   let message = "Done";
 
-  const audioFormatsWithCover = ["m4a", "mp3", "flac", "ogg"];
-  const audioFormatsNoCover = ["wav", "aac"];
-
-  const audioInputFormats = [
-    "aac",
-    "ac3",
-    "ac4",
-    "aiff",
-    "alac",
-    "amr",
-    "ape",
-    "au",
-    "caf",
-    "dts",
-    "eac3",
-    "flac",
-    "m4a",
-    "m4b",
-    "mka",
-    "mp2",
-    "mp3",
-    "mpc",
-    "ogg",
-    "oga",
-    "opus",
-    "ra",
-    "voc",
-    "wav",
-    "wma",
-    "wv",
-  ];
-
-  if (
-    audioFormatsWithCover.includes(convertTo) &&
-    audioInputFormats.includes(fileType.toLowerCase())
-  ) {
-    extraArgs.push("-c:v", "copy", "-disposition:v", "attached_pic");
-  } else if (audioFormatsNoCover.includes(convertTo) || audioFormatsWithCover.includes(convertTo)) {
-    extraArgs.push("-vn");
-  }
-
   if (convertTo === "ico") {
     // Make sure image is 256x256 or smaller
     extraArgs = [

--- a/src/converters/libreoffice.ts
+++ b/src/converters/libreoffice.ts
@@ -6,7 +6,6 @@ export const properties = {
     text: [
       "602",
       "abw",
-      "csv",
       "cwk",
       "doc",
       "docm",
@@ -35,7 +34,6 @@ export const properties = {
       "stw",
       "sxw",
       "tab",
-      "tsv",
       "txt",
       "wn",
       "wpd",
@@ -46,10 +44,10 @@ export const properties = {
       "xml",
       "zabw",
     ],
+    calc: ["csv", "ods", "tsv", "xls", "xlsx"],
   },
   to: {
     text: [
-      "csv",
       "doc",
       "docm",
       "docx",
@@ -65,13 +63,13 @@ export const properties = {
       "pdf",
       "rtf",
       "tab",
-      "tsv",
       "txt",
       "wps",
       "wpt",
       "xhtml",
       "xml",
     ],
+    calc: ["csv", "ods", "pdf", "tsv", "xls", "xlsx", "ots", "xlsm", "xlt", "xltm"],
   },
 };
 
@@ -117,7 +115,7 @@ const filters: Record<FileCategories, Record<string, string | null>> = {
     // filter makes soffice reject a genuine Works document with "source file
     // could not be loaded", even though it converts the same file fine with
     // no --infilter at all (LibreOffice auto-detects it correctly).
-    //
+
     // null is deliberate for BOTH directions here, not just the import side:
     // this map feeds both --infilter (import) and the --convert-to suffix
     // (export). On import, null lets LibreOffice auto-detect - its Works
@@ -133,7 +131,18 @@ const filters: Record<FileCategories, Record<string, string | null>> = {
     xml: "OpenDocument Text Flat XML",
     zabw: "AbiWord",
   },
-  calc: {},
+  calc: {
+    csv: "Text - txt - csv (StarCalc)",
+    ods: "calc8",
+    ots: "calc8_template",
+    pdf: "calc_pdf_Export",
+    tsv: "Text - txt - csv (StarCalc)",
+    xls: "MS Excel 97",
+    xlsx: "Calc MS Excel 2007 XML",
+    xlsm: "Calc MS Excel 2007 XML VBA",
+    xlt: "MS Excel 97 Vorlage",
+    xltm: "Calc MS Excel 2007 XML Template",
+  },
 };
 
 const getFilters = (fileType: string, converto: string) => {


### PR DESCRIPTION
**Summary**
Fix an issue where `.xls` and `.xlsx` files showed blank conversion options in the UI. While the underlying LibreOffice installation fully supported spreadsheets, the ConvertX `soffice` converter properties only had text formats registered. This PR introduces a dedicated `calc` category to handle spreadsheet files with their appropriate LibreOffice filters.

**Changes**
- Added a `calc` category to `properties.from` and `properties.to` to properly register spreadsheet extensions (`xls`, `xlsx`, `xlsm`, `ods`, etc.).
- Mapped the exact LibreOffice internal filters for spreadsheets in the `filters.calc` object (e.g., `Calc MS Excel 2007 XML` for `xlsx`, `calc_pdf_Export` for `pdf`).
- Configured CSV and TSV to use `Text - txt - csv (StarCalc)` to ensure they are processed as spreadsheets rather than plain text when applicable.
- Updated `getFilters` logic to check both `text` and `calc` categories dynamically based on the input and target formats.

**Validation**
- Uploaded `.xls` and `.xlsx` files; verified that the conversion dropdown now correctly populates with supported target formats.
- Verified successful conversion of `.xlsx` to `.pdf`.
- Verified successful conversion of `.xlsx` to `.csv` and vice versa.

Closes #602
Closes #581

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds spreadsheet conversion support to `soffice`, fixing blank targets for .xls/.xlsx. Also preserves embedded cover art in audio conversions with `ffmpeg` for supported formats.

- Adds a `calc` category; routes spreadsheet formats (`xls`, `xlsx`, `xlsm`, `xlt`, `xltm`, `ods`, `ots`, `csv`, `tsv`, `pdf`) to it and removes `csv`/`tsv` from `text`.
- Maps exact LibreOffice filters for these formats and updates selection to consider both `text` and `calc`; fixes source-format case handling.

<sup>Written for commit 832f92c4267e9b2d1d9771edd461ea56d05232bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/C4illin/ConvertX/pull/609?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

