### PR TITLE
feat(calibre): add azw3 to supported input formats

### DIFF
--- a/src/converters/calibre.ts
+++ b/src/converters/calibre.ts
@@ -4,6 +4,7 @@ import { ExecFileFn } from "./types";
 export const properties = {
   from: {
     document: [
+      "azw3",
       "azw4",
       "chm",
       "cbr",


### PR DESCRIPTION
## Description

This PR adds `azw3` to the list of supported input document formats in `properties.from.document`. 

Since Calibre under the hood is already capable of handling `.azw3` as an input file, adding it to the `from` properties enables users to select and convert `.azw3` files to `.epub` (and other formats) from the UI. 

## Related Issue
Closes #572


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `azw3` to `properties.from.document` so users can select and convert `.azw3` files in the UI. Previously `.azw3` uploads were blocked; now they convert to `.epub` and other formats, leveraging existing Calibre support without changing the conversion pipeline.

- Validate the UI accepts `.azw3` and that end-to-end conversion to `.epub` succeeds.
- No migrations or config changes required.

<sup>Written for commit 7d85366557ffce2b744228047a3aa4d0e678966f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/C4illin/ConvertX/pull/610?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

