### PR TITLE
feat(pdftops): added pdftops converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ A self-hosted online file converter. Supports over a thousand different formats.
 | [Potrace](https://potrace.sourceforge.net/)                     | Raster to vector | 4             | 11          |
 | [VTracer](https://github.com/visioncortex/vtracer)              | Raster to vector | 8             | 1           |
 | [Markitdown](https://github.com/microsoft/markitdown)           | Documents        | 6             | 1           |
+| [pdftops](https://poppler.freedesktop.org/)                     | Documents        | 1             | 2           |
 
 <!-- many ffmpeg fileformats are duplicates -->
 

--- a/src/converters/main.ts
+++ b/src/converters/main.ts
@@ -18,6 +18,7 @@ import { convert as convertLibjxl, properties as propertiesLibjxl } from "./libj
 import { convert as convertLibreOffice, properties as propertiesLibreOffice } from "./libreoffice";
 import { convert as convertMsgconvert, properties as propertiesMsgconvert } from "./msgconvert";
 import { convert as convertPandoc, properties as propertiesPandoc } from "./pandoc";
+import { convert as convertPdftops, properties as propertiesPdftops } from "./pdftops";
 import { convert as convertPotrace, properties as propertiesPotrace } from "./potrace";
 import { convert as convertresvg, properties as propertiesresvg } from "./resvg";
 import { convert as convertImage, properties as propertiesImage } from "./vips";
@@ -136,6 +137,10 @@ const properties: Record<
   markitDown: {
     properties: propertiesMarkitdown,
     converter: convertMarkitdown,
+  },
+  pdftops: {
+    properties: propertiesPdftops,
+    converter: convertPdftops,
   },
 };
 

--- a/src/converters/pdftops.ts
+++ b/src/converters/pdftops.ts
@@ -30,6 +30,7 @@ export async function convert(
     execFile("pdftops", args, (error, stdout, stderr) => {
       if (error) {
         reject(`error: ${error}`);
+        return;
       }
 
       if (stdout) {
@@ -37,7 +38,7 @@ export async function convert(
       }
 
       if (stderr) {
-        console.log(`stderr: ${stderr}`);
+        console.error(`stderr: ${stderr}`);
       }
 
       resolve("Done");

--- a/src/converters/pdftops.ts
+++ b/src/converters/pdftops.ts
@@ -1,0 +1,46 @@
+import { execFile as execFileOriginal } from "node:child_process";
+import { ExecFileFn } from "./types";
+
+export const properties = {
+  from: {
+    document: ["pdf"],
+  },
+  to: {
+    document: ["eps", "ps"],
+  },
+};
+
+export async function convert(
+  filePath: string,
+  fileType: string,
+  convertTo: string,
+  targetPath: string,
+  options?: unknown,
+  execFile: ExecFileFn = execFileOriginal, // to make it mockable
+): Promise<string> {
+  const args: string[] = [];
+
+  if (convertTo === "eps") {
+    args.push("-eps");
+  }
+
+  args.push(filePath, targetPath);
+
+  return new Promise((resolve, reject) => {
+    execFile("pdftops", args, (error, stdout, stderr) => {
+      if (error) {
+        reject(`error: ${error}`);
+      }
+
+      if (stdout) {
+        console.log(`stdout: ${stdout}`);
+      }
+
+      if (stderr) {
+        console.log(`stderr: ${stderr}`);
+      }
+
+      resolve("Done");
+    });
+  });
+}

--- a/tests/converters/pdftops.test.ts
+++ b/tests/converters/pdftops.test.ts
@@ -49,7 +49,7 @@ test("adds -eps flag for eps output", async () => {
 
 test("fails on exec error", async () => {
   expect(convert("fail.pdf", "pdf", "ps", "output.ps", undefined, mockExecFile)).rejects.toMatch(
-    /error: Error: mock failure/
+    /error: Error: mock failure/,
   );
 });
 

--- a/tests/converters/pdftops.test.ts
+++ b/tests/converters/pdftops.test.ts
@@ -48,8 +48,8 @@ test("adds -eps flag for eps output", async () => {
 });
 
 test("fails on exec error", async () => {
-  expect(convert("fail.pdf", "pdf", "ps", "output.ps", undefined, mockExecFile)).rejects.toThrow(
-    "mock failure",
+  expect(convert("fail.pdf", "pdf", "ps", "output.ps", undefined, mockExecFile)).rejects.toMatch(
+    /error: Error: mock failure/
   );
 });
 

--- a/tests/converters/pdftops.test.ts
+++ b/tests/converters/pdftops.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, expect, test } from "bun:test";
+import { convert } from "../../src/converters/pdftops";
+import { runCommonTests } from "./helpers/commonTests";
+
+runCommonTests(convert);
+
+let calls: string[][] = [];
+
+function mockExecFile(
+  _cmd: string,
+  args: string[],
+  callback: (err: Error | null, stdout: string, stderr: string) => void,
+) {
+  calls.push(args);
+  if (args.includes("fail.pdf")) {
+    callback(new Error("mock failure"), "", "Fake stderr: fail");
+  } else {
+    callback(null, "Fake stdout", "");
+  }
+}
+
+beforeEach(() => {
+  calls = [];
+});
+
+test("converts a normal file to ps", async () => {
+  const originalConsoleLog = console.log;
+
+  let loggedMessage = "";
+  console.log = (msg) => {
+    loggedMessage = msg;
+  };
+
+  const result = await convert("in.pdf", "pdf", "ps", "out.ps", undefined, mockExecFile);
+
+  console.log = originalConsoleLog;
+
+  expect(result).toBe("Done");
+  expect(calls[0]).toEqual(["in.pdf", "out.ps"]);
+  expect(loggedMessage).toBe("stdout: Fake stdout");
+});
+
+test("adds -eps flag for eps output", async () => {
+  const result = await convert("in.pdf", "pdf", "eps", "out.eps", undefined, mockExecFile);
+
+  expect(result).toBe("Done");
+  expect(calls[0]).toEqual(["-eps", "in.pdf", "out.eps"]);
+});
+
+test("fails on exec error", async () => {
+  expect(convert("fail.pdf", "pdf", "ps", "output.ps", undefined, mockExecFile)).rejects.toThrow(
+    "mock failure",
+  );
+});
+
+test("logs stderr when execFile returns only stderr and no error", async () => {
+  const originalConsoleError = console.error;
+
+  let loggedMessage = "";
+  console.error = (msg) => {
+    loggedMessage = msg;
+  };
+
+  const mockExecFileStderrOnly = (
+    _cmd: string,
+    _args: string[],
+    callback: (err: Error | null, stdout: string, stderr: string) => void,
+  ) => {
+    callback(null, "", "Only stderr output");
+  };
+
+  await convert("input.pdf", "pdf", "ps", "output.ps", undefined, mockExecFileStderrOnly);
+
+  console.error = originalConsoleError;
+
+  expect(loggedMessage).toBe("stderr: Only stderr output");
+});


### PR DESCRIPTION
## Description

This PR introduces a new converter utilizing the `pdftops` CLI utility (part of the `poppler-utils` package).

It adds support for converting PDF documents into PostScript formats. 

**Supported conversions:**
* **From:** `pdf`
* **To:** `ps`, `eps`

The logic automatically appends the `-eps` flag when the target format is `eps`.

*Note for maintainers: This converter relies on the `pdftops` command. If the host environment or Docker image does not already include it, the `poppler-utils` package will need to be installed.*

Closes #529 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `pdftops` converter to produce PS and EPS from PDF, enabling PostScript outputs that were previously unsupported. Requires the `pdftops` binary from `poppler-utils`.

- Registers `pdftops` for `pdf` → `ps`/`eps` and documents it in README.
- Invokes `pdftops <input> <output>`; appends `-eps` for EPS; logs stdout/stderr and surfaces execution errors.
- Adds tests for the EPS flag, stdout/stderr logging (including stderr-only), and error handling.

<sup>Written for commit a4f200f98fb91b93533838a0f3569dbd09d536d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/C4illin/ConvertX/pull/611?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

