### PR TITLE
feat: add DjVu conversion support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,7 @@ RUN apt-get update && apt-get install -y \
   calibre \
   dasel \
   dcraw \
+  djvulibre-bin \
   dvisvgm \
   ffmpeg \
   ghostscript \

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ A self-hosted online file converter. Supports over a thousand different formats.
 | [Calibre](https://calibre-ebook.com/)                           | E-books          | 26            | 19          |
 | [LibreOffice](https://www.libreoffice.org/)                     | Documents        | 41            | 22          |
 | [Dasel](https://github.com/TomWright/dasel)                     | Data Files       | 5             | 4           |
+| [DjVuLibre](https://djvu.sourceforge.net/)                       | Documents        | 1             | 2           |
 | [Pandoc](https://pandoc.org/)                                   | Documents        | 43            | 65          |
 | [msgconvert](https://github.com/mvz/email-outlook-message-perl) | Outlook          | 1             | 1           |
 | VCF to CSV                                                      | Contacts         | 1             | 1           |

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ A self-hosted online file converter. Supports over a thousand different formats.
 | [Calibre](https://calibre-ebook.com/)                           | E-books          | 26            | 19          |
 | [LibreOffice](https://www.libreoffice.org/)                     | Documents        | 41            | 22          |
 | [Dasel](https://github.com/TomWright/dasel)                     | Data Files       | 5             | 4           |
-| [DjVuLibre](https://djvu.sourceforge.net/)                       | Documents        | 1             | 2           |
+| [DjVuLibre](https://djvu.sourceforge.net/)                       | Documents        | 2             | 2           |
 | [Pandoc](https://pandoc.org/)                                   | Documents        | 43            | 65          |
 | [msgconvert](https://github.com/mvz/email-outlook-message-perl) | Outlook          | 1             | 1           |
 | VCF to CSV                                                      | Contacts         | 1             | 1           |

--- a/src/converters/djvu.ts
+++ b/src/converters/djvu.ts
@@ -3,7 +3,7 @@ import type { ExecFileFn } from "./types";
 
 export const properties = {
   from: {
-    document: ["djvu"],
+    document: ["djvu", "djv"],
   },
   to: {
     document: ["pdf", "tiff"],

--- a/src/converters/djvu.ts
+++ b/src/converters/djvu.ts
@@ -1,0 +1,39 @@
+import { execFile as execFileOriginal } from "node:child_process";
+import type { ExecFileFn } from "./types";
+
+export const properties = {
+  from: {
+    document: ["djvu"],
+  },
+  to: {
+    document: ["pdf", "tiff"],
+  },
+};
+
+export function convert(
+  filePath: string,
+  _fileType: string,
+  convertTo: string,
+  targetPath: string,
+  _options?: unknown,
+  execFile: ExecFileFn = execFileOriginal,
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile("ddjvu", [`-format=${convertTo}`, filePath, targetPath], (error, stdout, stderr) => {
+      if (error) {
+        reject(`error: ${error}${stderr ? `\nstderr: ${stderr}` : ""}`);
+        return;
+      }
+
+      if (stdout) {
+        console.log(`stdout: ${stdout}`);
+      }
+
+      if (stderr) {
+        console.error(`stderr: ${stderr}`);
+      }
+
+      resolve("Done");
+    });
+  });
+}

--- a/src/converters/main.ts
+++ b/src/converters/main.ts
@@ -5,6 +5,7 @@ import { normalizeFiletype, normalizeOutputFiletype } from "../helpers/normalize
 import { convert as convertassimp, properties as propertiesassimp } from "./assimp";
 import { convert as convertCalibre, properties as propertiesCalibre } from "./calibre";
 import { convert as convertDasel, properties as propertiesDasel } from "./dasel";
+import { convert as convertDjvu, properties as propertiesDjvu } from "./djvu";
 import { convert as convertDvisvgm, properties as propertiesDvisvgm } from "./dvisvgm";
 import { convert as convertFFmpeg, properties as propertiesFFmpeg } from "./ffmpeg";
 import {
@@ -88,6 +89,10 @@ const properties: Record<
   dasel: {
     properties: propertiesDasel,
     converter: convertDasel,
+  },
+  djvu: {
+    properties: propertiesDjvu,
+    converter: convertDjvu,
   },
   libreoffice: {
     properties: propertiesLibreOffice,

--- a/src/converters/main.ts
+++ b/src/converters/main.ts
@@ -82,10 +82,6 @@ const properties: Record<
     properties: propertiesxelatex,
     converter: convertxelatex,
   },
-  djvu: {
-    properties: propertiesDjvu,
-    converter: convertDjvu,
-  },
   calibre: {
     properties: propertiesCalibre,
     converter: convertCalibre,
@@ -93,6 +89,10 @@ const properties: Record<
   dasel: {
     properties: propertiesDasel,
     converter: convertDasel,
+  },
+  djvu: {
+    properties: propertiesDjvu,
+    converter: convertDjvu,
   },
   libreoffice: {
     properties: propertiesLibreOffice,

--- a/src/converters/main.ts
+++ b/src/converters/main.ts
@@ -82,6 +82,10 @@ const properties: Record<
     properties: propertiesxelatex,
     converter: convertxelatex,
   },
+  djvu: {
+    properties: propertiesDjvu,
+    converter: convertDjvu,
+  },
   calibre: {
     properties: propertiesCalibre,
     converter: convertCalibre,
@@ -89,10 +93,6 @@ const properties: Record<
   dasel: {
     properties: propertiesDasel,
     converter: convertDasel,
-  },
-  djvu: {
-    properties: propertiesDjvu,
-    converter: convertDjvu,
   },
   libreoffice: {
     properties: propertiesLibreOffice,

--- a/tests/converters/djvu.test.ts
+++ b/tests/converters/djvu.test.ts
@@ -8,7 +8,7 @@ runCommonTests(convert);
 
 test("advertises DjVu to PDF and TIFF conversions", () => {
   expect(properties).toEqual({
-    from: { document: ["djvu"] },
+    from: { document: ["djvu", "djv"] },
     to: { document: ["pdf", "tiff"] },
   });
 });

--- a/tests/converters/djvu.test.ts
+++ b/tests/converters/djvu.test.ts
@@ -1,0 +1,36 @@
+import type { ExecFileException } from "node:child_process";
+import { expect, test } from "bun:test";
+import { convert, properties } from "../../src/converters/djvu";
+import type { ExecFileFn } from "../../src/converters/types";
+import { runCommonTests } from "./helpers/commonTests";
+
+runCommonTests(convert);
+
+test("advertises DjVu to PDF and TIFF conversions", () => {
+  expect(properties).toEqual({
+    from: { document: ["djvu"] },
+    to: { document: ["pdf", "tiff"] },
+  });
+});
+
+for (const format of ["pdf", "tiff"]) {
+  test(`calls ddjvu with the ${format} output format`, async () => {
+    let command = "";
+    let args: string[] = [];
+    const mockExecFile: ExecFileFn = (
+      cmd: string,
+      commandArgs: string[],
+      callback: (err: ExecFileException | null, stdout: string, stderr: string) => void,
+    ) => {
+      command = cmd;
+      args = commandArgs;
+      callback(null, "", "");
+    };
+
+    await expect(
+      convert("input.djvu", "djvu", format, `output.${format}`, undefined, mockExecFile),
+    ).resolves.toBe("Done");
+    expect(command).toBe("ddjvu");
+    expect(args).toEqual([`-format=${format}`, "input.djvu", `output.${format}`]);
+  });
+}


### PR DESCRIPTION
## Summary

- install DjVuLibre's `ddjvu` utility in the production image
- add DjVu-to-PDF and DjVu-to-TIFF conversion through `ddjvu`
- register and document the new converter
- add unit coverage for converter metadata, command arguments, logging, and failures

## Notes

`ddjvu` renders each page into the resulting PDF or TIFF. This supports scanned/image-only DjVu documents that Calibre cannot convert, but it does not preserve an embedded searchable text layer.

## Testing

- `bun test` — 107 passed, 8 skipped, 0 failed
- `tsc --noEmit`
- `knip`
- Prettier and ESLint checks for the changed TypeScript files

Closes #583

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds DjVu-to-PDF and DjVu-to-TIFF conversion via `ddjvu`, so DjVu inputs that previously failed now convert. Output is rasterized; embedded searchable text is not preserved.

- Installs `djvulibre-bin`.
- Registers a dedicated `djvu` converter for `.djvu`/`.djv` and restores its priority ahead of generic document converters.
- Runs `ddjvu -format=<pdf|tiff>` and logs stdout/stderr.
- Updates README and adds unit tests.

**Rollout**
- No API changes.
- Local development must install `djvulibre-bin` or use the updated image.

<sup>Written for commit b9f49f0d3472d6e95f42affaafd6751fe3851809. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/C4illin/ConvertX/pull/612?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

