### PR TITLE
feat(bsdtar): add archive converter using bsdtar

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,7 @@ RUN apt-get update && apt-get install -y \
   imagemagick-7.q16 \
   inkscape \
   latexmk \
+  libarchive-tools \
   libheif-examples \
   libjxl-tools \
   libreoffice \

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ A self-hosted online file converter. Supports over a thousand different formats.
 | [Potrace](https://potrace.sourceforge.net/)                     | Raster to vector | 4             | 11          |
 | [VTracer](https://github.com/visioncortex/vtracer)              | Raster to vector | 8             | 1           |
 | [Markitdown](https://github.com/microsoft/markitdown)           | Documents        | 6             | 1           |
+| [bsdtar](https://libarchive.org/)                               | Archives         | 16            | 6           |
 
 <!-- many ffmpeg fileformats are duplicates -->
 

--- a/src/converters/bsdtar.ts
+++ b/src/converters/bsdtar.ts
@@ -1,0 +1,58 @@
+import { execFile as execFileOriginal } from "node:child_process";
+import { ExecFileFn } from "./types";
+
+export const properties = {
+  from: {
+    archive: [
+      "7z",
+      "bz2",
+      "cab",
+      "cpio",
+      "gz",
+      "iso",
+      "rar",
+      "tar",
+      "tar.bz2",
+      "tar.gz",
+      "tar.xz",
+      "tbz2",
+      "tgz",
+      "txz",
+      "xz",
+      "zip",
+    ],
+  },
+  to: {
+    archive: ["7z", "tar", "tar.bz2", "tar.gz", "tar.xz", "zip"],
+  },
+};
+
+export async function convert(
+  filePath: string,
+  fileType: string,
+  convertTo: string,
+  targetPath: string,
+  options?: unknown,
+  execFile: ExecFileFn = execFileOriginal, // to make it mockable
+): Promise<string> {
+  const args: string[] = ["-a", "-cf", targetPath, `@${filePath}`];
+
+  return new Promise((resolve, reject) => {
+    execFile("bsdtar", args, (error, stdout, stderr) => {
+      if (error) {
+        reject(`error: ${error}`);
+        return;
+      }
+
+      if (stdout) {
+        console.log(`stdout: ${stdout}`);
+      }
+
+      if (stderr) {
+        console.error(`stderr: ${stderr}`);
+      }
+
+      resolve("Done");
+    });
+  });
+}

--- a/src/converters/main.ts
+++ b/src/converters/main.ts
@@ -3,6 +3,7 @@ import db from "../db/db";
 import { MAX_CONVERT_PROCESS } from "../helpers/env";
 import { normalizeFiletype, normalizeOutputFiletype } from "../helpers/normalizeFiletype";
 import { convert as convertassimp, properties as propertiesassimp } from "./assimp";
+import { convert as convertBsdtar, properties as propertiesBsdtar } from "./bsdtar";
 import { convert as convertCalibre, properties as propertiesCalibre } from "./calibre";
 import { convert as convertDasel, properties as propertiesDasel } from "./dasel";
 import { convert as convertDvisvgm, properties as propertiesDvisvgm } from "./dvisvgm";
@@ -136,6 +137,10 @@ const properties: Record<
   markitDown: {
     properties: propertiesMarkitdown,
     converter: convertMarkitdown,
+  },
+  bsdtar: {
+    properties: propertiesBsdtar,
+    converter: convertBsdtar,
   },
 };
 

--- a/tests/converters/bsdtar.test.ts
+++ b/tests/converters/bsdtar.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, expect, test } from "bun:test";
+import { convert } from "../../src/converters/bsdtar";
+import type { ExecFileFn } from "../../src/converters/types";
+import { runCommonTests } from "./helpers/commonTests";
+
+let calls: string[][] = [];
+let cmdCalled = "";
+
+beforeEach(() => {
+  calls = [];
+  cmdCalled = "";
+});
+
+runCommonTests(convert);
+
+test("converts an archive file using bsdtar", async () => {
+  const originalConsoleLog = console.log;
+  let loggedMessage = "";
+  console.log = (msg) => {
+    loggedMessage = msg;
+  };
+
+  const mockExecFile: ExecFileFn = (cmd, args, callback) => {
+    cmdCalled = cmd;
+    calls.push(args);
+    callback(null, "Fake stdout", "");
+  };
+
+  const result = await convert("input.rar", "rar", "zip", "output.zip", undefined, mockExecFile);
+
+  console.log = originalConsoleLog;
+
+  expect(result).toBe("Done");
+
+  expect(cmdCalled).toBe("bsdtar");
+
+  expect(calls[0]).toEqual(["-a", "-cf", "output.zip", "@input.rar"]);
+
+  expect(loggedMessage).toBe("stdout: Fake stdout");
+});
+
+test("fails on exec error", async () => {
+  const mockExecFile: ExecFileFn = (cmd, args, callback) => {
+    callback(new Error("mock failure"), "", "");
+  };
+
+  await expect(
+    convert("fail.rar", "rar", "zip", "output.zip", undefined, mockExecFile),
+  ).rejects.toMatch(/error: Error: mock failure/);
+});


### PR DESCRIPTION
## Description

This PR introduces a new converter for archive files using `bsdtar` (part of the `libarchive-tools` package), satisfying the request for archive format support.

While the original issue suggested PeaZip, `bsdtar` is much better suited for this environment. By utilizing the `@` syntax (`bsdtar -a -cf target.zip @source.rar`), `bsdtar` can read the contents of the source archive and repack them directly into the target archive on-the-fly, without needing to extract files to a temporary folder on the disk.

**Supported conversions:**
* **From (16):** `7z`, `bz2`, `cab`, `cpio`, `gz`, `iso`, `rar`, `tar`, `tar.bz2`, `tar.gz`, `tar.xz`, `tbz2`, `tgz`, `txz`, `xz`, `zip`
* **To (6):** `7z`, `tar`, `tar.bz2`, `tar.gz`, `tar.xz`, `zip`

*(Note: Creating `.rar` files is not supported as the RAR creation algorithm is proprietary/licensed, but extracting from `.rar` works perfectly).*

*Note for maintainers: This relies on the `bsdtar` command. If the host environment or Docker image does not already include it, the `libarchive-tools` package will need to be installed via `apt-get`.*

## Related Issue
Closes #437

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an archive converter using `bsdtar` for on-the-fly repacking without disk extraction. Previously archive-to-archive conversion was not supported; now we can convert common archives to `7z`, `tar`, `tar.bz2`, `tar.gz`, `tar.xz`, and `zip` (RAR creation remains unsupported).

- Registers the `bsdtar` converter and properties; runs `bsdtar -a -cf <target> @<source>`.
- Installs `libarchive-tools` in the Docker image; if you deploy without our Dockerfile, install `libarchive-tools` so `bsdtar` is available.
- Supports 16 input archive formats, including `7z`, `rar`, `tar.*`, `xz`, `gz`, and `zip`.
- Adds tests for success and exec error handling; updates README to list `bsdtar`.

<sup>Written for commit 15034a37272e62dc06a24d44120562809ae68ac9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/C4illin/ConvertX/pull/613?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

