### PR TITLE
ci: add xss scan

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -2,6 +2,24 @@
   "$schema": "https://unpkg.com/knip@6/schema.json",
   "entry": ["tests/**/*.test.ts"],
   "project": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.css", "tests/**/*.ts"],
+  "ignoreBinaries": [
+    "pandoc",
+    "ffmpeg",
+    "vips",
+    "magick",
+    "gm",
+    "inkscape",
+    "djxl",
+    "dasel",
+    "xelatex",
+    "resvg",
+    "assimp",
+    "ebook-convert",
+    "heif-info",
+    "potrace",
+    "soffice",
+    "perl"
+  ],
   "tailwind": {
     "entry": ["src/main.css"]
   }

--- a/knip.json
+++ b/knip.json
@@ -2,24 +2,6 @@
   "$schema": "https://unpkg.com/knip@6/schema.json",
   "entry": ["tests/**/*.test.ts"],
   "project": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.css", "tests/**/*.ts"],
-  "ignoreBinaries": [
-    "pandoc",
-    "ffmpeg",
-    "vips",
-    "magick",
-    "gm",
-    "inkscape",
-    "djxl",
-    "dasel",
-    "xelatex",
-    "resvg",
-    "assimp",
-    "ebook-convert",
-    "heif-info",
-    "potrace",
-    "soffice",
-    "perl"
-  ],
   "tailwind": {
     "entry": ["src/main.css"]
   }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "lint:tsc": "tsc --noEmit",
     "lint:knip": "knip",
     "lint:eslint": "eslint .",
-    "lint:prettier": "prettier --check ."
+    "lint:prettier": "prettier --check .",
+    "lint:xss": "xss-scan"
   },
   "dependencies": {
     "@elysiajs/html": "^1.4.2",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds an XSS scan to the lint suite to catch DOM/reflected XSS patterns early. Previously we had no XSS check; now `lint:xss` runs `xss-scan` without affecting build or runtime.

- Only change: adds `lint:xss` in `package.json`.

**Rollout**
- CI: invoke `pnpm run lint:xss` (or `npm run lint:xss`) in the lint job.
- Developers: run `pnpm run lint:xss` locally before merging.

<sup>Written for commit 8da22fa2960a54859a08447c6788facca953edf1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/C4illin/ConvertX/pull/614?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

