### PR TITLE
fix: bound clearJobs rm so FUSE hidden files cannot hang auto-delete

### DIFF
--- a/src/helpers/clearJobs.ts
+++ b/src/helpers/clearJobs.ts
@@ -1,0 +1,57 @@
+import type { Database } from "bun:sqlite";
+import { Jobs } from "../db/types";
+import { rmBounded } from "./rmBounded";
+
+export function clearExpiredJobs(options: {
+  db: Database;
+  outputDir: string;
+  uploadsDir: string;
+  olderThan: Date;
+  rm?: (path: string) => void;
+}): void {
+  const rm = options.rm ?? ((path: string) => rmBounded(path));
+  const jobs = options.db
+    .query("SELECT * FROM jobs WHERE date_created < ?")
+    .as(Jobs)
+    .all(options.olderThan.toISOString());
+
+  for (const job of jobs) {
+    try {
+      rm(`${options.outputDir}${job.user_id}/${job.id}`);
+      rm(`${options.uploadsDir}${job.user_id}/${job.id}`);
+      options.db.query("DELETE FROM jobs WHERE id = ?").run(job.id);
+    } catch (error) {
+      console.error(`Failed to delete expired job ${job.id}:`, error);
+    }
+  }
+}
+
+export function startJobCleanup(options: {
+  db: Database;
+  outputDir: string;
+  uploadsDir: string;
+  intervalHours: number;
+  rm?: (path: string) => void;
+  schedule?: (callback: () => void, delay: number) => unknown;
+}): void {
+  const schedule = options.schedule ?? setTimeout;
+  const delay = options.intervalHours * 60 * 60 * 1000;
+
+  const tick = () => {
+    try {
+      clearExpiredJobs({
+        db: options.db,
+        outputDir: options.outputDir,
+        uploadsDir: options.uploadsDir,
+        olderThan: new Date(Date.now() - delay),
+        ...(options.rm !== undefined ? { rm: options.rm } : {}),
+      });
+    } catch (error) {
+      console.error("Failed to clear expired jobs:", error);
+    } finally {
+      schedule(tick, delay);
+    }
+  };
+
+  tick();
+}

--- a/src/helpers/rmBounded.ts
+++ b/src/helpers/rmBounded.ts
@@ -1,0 +1,89 @@
+import { lstatSync, readdirSync, rmdirSync, unlinkSync } from "node:fs";
+import { join } from "node:path";
+
+export type RmFs = {
+  lstatSync: (path: string) => { isDirectory(): boolean };
+  readdirSync: (path: string) => string[];
+  unlinkSync: (path: string) => void;
+  rmdirSync: (path: string) => void;
+};
+
+const defaultFs: RmFs = {
+  lstatSync,
+  readdirSync,
+  unlinkSync,
+  rmdirSync,
+};
+
+const DEFAULT_MAX_RETRIES = 3;
+
+function errorCode(err: unknown): string | undefined {
+  if (err && typeof err === "object" && "code" in err && typeof err.code === "string") {
+    return err.code;
+  }
+  return undefined;
+}
+
+export function rmBounded(
+  targetPath: string,
+  options: { maxRetries?: number } = {},
+  fsImpl: RmFs = defaultFs,
+): void {
+  const maxRetries = options.maxRetries ?? DEFAULT_MAX_RETRIES;
+  try {
+    rmPath(targetPath, maxRetries, fsImpl);
+  } catch (err) {
+    if (errorCode(err) === "ENOENT") {
+      return;
+    }
+    throw err;
+  }
+}
+
+function rmPath(targetPath: string, retriesLeft: number, fsImpl: RmFs): void {
+  let stat: { isDirectory(): boolean };
+  try {
+    stat = fsImpl.lstatSync(targetPath);
+  } catch (err) {
+    if (errorCode(err) === "ENOENT") {
+      return;
+    }
+    throw err;
+  }
+
+  if (!stat.isDirectory()) {
+    fsImpl.unlinkSync(targetPath);
+    return;
+  }
+
+  rmDirectory(targetPath, retriesLeft, fsImpl);
+}
+
+function rmDirectory(targetPath: string, retriesLeft: number, fsImpl: RmFs): void {
+  let entries: string[];
+  try {
+    entries = fsImpl.readdirSync(targetPath);
+  } catch (err) {
+    if (errorCode(err) === "ENOENT") {
+      return;
+    }
+    throw err;
+  }
+
+  for (const entry of entries) {
+    rmPath(join(targetPath, entry), retriesLeft, fsImpl);
+  }
+
+  try {
+    fsImpl.rmdirSync(targetPath);
+  } catch (err) {
+    if (errorCode(err) === "ENOENT") {
+      return;
+    }
+    if (errorCode(err) === "ENOTEMPTY" && retriesLeft > 0) {
+      rmDirectory(targetPath, retriesLeft - 1, fsImpl);
+      return;
+    }
+    throw err;
+  }
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,10 +1,9 @@
-import { rmSync } from "node:fs";
 import { html } from "@elysiajs/html";
 import { staticPlugin } from "@elysiajs/static";
 import { Elysia } from "elysia";
 import "./helpers/printVersions";
 import db from "./db/db";
-import { Jobs } from "./db/types";
+import { startJobCleanup } from "./helpers/clearJobs";
 import { AUTO_DELETE_EVERY_N_HOURS, WEBROOT } from "./helpers/env";
 import { chooseConverter } from "./pages/chooseConverter";
 import { convert } from "./pages/convert";
@@ -73,30 +72,11 @@ app.listen(process.env.PORT || 3000);
 
 console.log(`🦊 Elysia is running at http://${app.server?.hostname}:${app.server?.port}${WEBROOT}`);
 
-const clearJobs = () => {
-  const jobs = db
-    .query("SELECT * FROM jobs WHERE date_created < ?")
-    .as(Jobs)
-    .all(new Date(Date.now() - AUTO_DELETE_EVERY_N_HOURS * 60 * 60 * 1000).toISOString());
-
-  for (const job of jobs) {
-    // delete the directories
-    rmSync(`${outputDir}${job.user_id}/${job.id}`, {
-      recursive: true,
-      force: true,
-    });
-    rmSync(`${uploadsDir}${job.user_id}/${job.id}`, {
-      recursive: true,
-      force: true,
-    });
-
-    // delete the job
-    db.query("DELETE FROM jobs WHERE id = ?").run(job.id);
-  }
-
-  setTimeout(clearJobs, AUTO_DELETE_EVERY_N_HOURS * 60 * 60 * 1000);
-};
-
 if (AUTO_DELETE_EVERY_N_HOURS > 0) {
-  clearJobs();
+  startJobCleanup({
+    db,
+    outputDir,
+    uploadsDir,
+    intervalHours: AUTO_DELETE_EVERY_N_HOURS,
+  });
 }

--- a/tests/helpers/clearJobs.test.ts
+++ b/tests/helpers/clearJobs.test.ts
@@ -1,0 +1,109 @@
+import { afterAll, afterEach, expect, spyOn, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import { clearExpiredJobs, startJobCleanup } from "../../src/helpers/clearJobs";
+
+const consoleError = spyOn(console, "error").mockImplementation(() => {});
+
+afterEach(() => {
+  consoleError.mockClear();
+});
+
+afterAll(() => {
+  consoleError.mockRestore();
+});
+
+function setupDb() {
+  const db = new Database(":memory:");
+  db.exec(`
+    CREATE TABLE jobs (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      user_id INTEGER NOT NULL,
+      date_created TEXT NOT NULL,
+      status TEXT DEFAULT 'not started',
+      num_files INTEGER DEFAULT 0
+    );
+  `);
+  return db;
+}
+
+function insertJob(db: Database, userId: number, dateCreated: string): number {
+  db.query("INSERT INTO jobs (user_id, date_created) VALUES (?, ?)").run(userId, dateCreated);
+  const row = db.query("SELECT id FROM jobs ORDER BY id DESC").get() as { id: number };
+  return row.id;
+}
+
+function jobIds(db: Database): number[] {
+  return db
+    .query("SELECT id FROM jobs ORDER BY id")
+    .all()
+    .map((row) => (row as { id: number }).id);
+}
+
+test("clearExpiredJobs continues when one job directory cannot be deleted", () => {
+  const db = setupDb();
+  const old = new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString();
+  const stuckId = insertJob(db, 1, old);
+  const okId = insertJob(db, 1, old);
+  const removed: string[] = [];
+
+  clearExpiredJobs({
+    db,
+    outputDir: "./data/output/",
+    uploadsDir: "./data/uploads/",
+    olderThan: new Date(),
+    rm: (path) => {
+      if (path.endsWith(`/${stuckId}`)) {
+        throw Object.assign(new Error("ENOTEMPTY: directory not empty"), { code: "ENOTEMPTY" });
+      }
+      removed.push(path);
+    },
+  });
+
+  expect(jobIds(db)).toEqual([stuckId]);
+  expect(removed).toContain(`./data/output/1/${okId}`);
+  expect(removed).toContain(`./data/uploads/1/${okId}`);
+});
+
+test("startJobCleanup reschedules even when deletion throws", () => {
+  const db = setupDb();
+  insertJob(db, 1, new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString());
+
+  const scheduled: { delay: number }[] = [];
+  startJobCleanup({
+    db,
+    outputDir: "./data/output/",
+    uploadsDir: "./data/uploads/",
+    intervalHours: 24,
+    rm: () => {
+      throw new Error("rmSync hung or failed");
+    },
+    schedule: (_callback, delay) => {
+      scheduled.push({ delay });
+      return 0;
+    },
+  });
+
+  expect(scheduled).toHaveLength(1);
+  expect(scheduled[0]?.delay).toBe(24 * 60 * 60 * 1000);
+});
+
+test("startJobCleanup reschedules when listing jobs throws", () => {
+  const scheduled: { delay: number }[] = [];
+  startJobCleanup({
+    db: {
+      query: () => {
+        throw new Error("db unavailable");
+      },
+    } as unknown as Database,
+    outputDir: "./data/output/",
+    uploadsDir: "./data/uploads/",
+    intervalHours: 24,
+    schedule: (_callback, delay) => {
+      scheduled.push({ delay });
+      return 0;
+    },
+  });
+
+  expect(scheduled).toHaveLength(1);
+  expect(scheduled[0]?.delay).toBe(24 * 60 * 60 * 1000);
+});

--- a/tests/helpers/rmBounded.test.ts
+++ b/tests/helpers/rmBounded.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, expect, test } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, join } from "node:path";
+import { rmBounded, type RmFs } from "../../src/helpers/rmBounded";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    try {
+      rmBounded(dir, { maxRetries: 2 });
+    } catch {
+      // test cleanup best-effort
+    }
+  }
+});
+
+function errno(code: string, message = code): NodeJS.ErrnoException {
+  const err = new Error(message) as NodeJS.ErrnoException;
+  err.code = code;
+  return err;
+}
+
+/**
+ * FUSE (shfs/sshfs/mergerfs) keeps a directory entry for an unlinked file
+ * that still has an open fd by renaming it to `.fuse_hidden<hex>` on every
+ * unlink. An unbounded recursive rm then never converges.
+ */
+function createFuseHiddenFs(root: string, leakedFile: string): RmFs & { unlinks: number } {
+  const files = new Set<string>([leakedFile]);
+  let hiddenSeq = 0;
+  const fsImpl: RmFs & { unlinks: number } = {
+    unlinks: 0,
+    lstatSync(path: string) {
+      if (path === root) {
+        return { isDirectory: () => true };
+      }
+      const name = basename(path);
+      if (!files.has(name)) {
+        throw errno("ENOENT", `ENOENT: ${path}`);
+      }
+      return { isDirectory: () => false };
+    },
+    readdirSync(path: string) {
+      if (path !== root) {
+        throw errno("ENOTDIR", `ENOTDIR: ${path}`);
+      }
+      return [...files];
+    },
+    unlinkSync(path: string) {
+      fsImpl.unlinks += 1;
+      if (fsImpl.unlinks > 200) {
+        throw new Error("unbounded unlink loop");
+      }
+      const name = basename(path);
+      files.delete(name);
+      files.add(`.fuse_hidden${hiddenSeq.toString(16).padStart(16, "0")}`);
+      hiddenSeq += 1;
+    },
+    rmdirSync(path: string) {
+      if (path !== root) {
+        throw errno("ENOENT", `ENOENT: ${path}`);
+      }
+      if (files.size > 0) {
+        throw errno("ENOTEMPTY", "ENOTEMPTY: directory not empty");
+      }
+    },
+  };
+  return fsImpl;
+}
+
+test("rmBounded gives up when FUSE recreates .fuse_hidden entries after unlink", () => {
+  const root = "/app/data/output/1/9";
+  const fsImpl = createFuseHiddenFs(root, "clip.h264.mp4");
+
+  let thrown: unknown;
+  try {
+    rmBounded(root, { maxRetries: 2 }, fsImpl);
+  } catch (err) {
+    thrown = err;
+  }
+
+  expect(thrown).toBeDefined();
+  expect((thrown as Error).message).not.toBe("unbounded unlink loop");
+  expect((thrown as NodeJS.ErrnoException).code).toBe("ENOTEMPTY");
+  expect(fsImpl.unlinks).toBeGreaterThan(0);
+  expect(fsImpl.unlinks).toBeLessThanOrEqual(6);
+});
+
+test("rmBounded removes a real directory tree", () => {
+  const root = mkdtempSync(join(tmpdir(), "convertx-rm-"));
+  tempDirs.push(root);
+  mkdirSync(join(root, "nested"));
+  writeFileSync(join(root, "a.txt"), "a");
+  writeFileSync(join(root, "nested", "b.txt"), "b");
+
+  rmBounded(root);
+
+  expect(existsSync(root)).toBe(false);
+});
+
+test("rmBounded with force ignores a missing path", () => {
+  expect(() => rmBounded(join(tmpdir(), "convertx-missing-" + Date.now()))).not.toThrow();
+});


### PR DESCRIPTION
## Summary

`clearJobs()` called unbounded `rmSync({ recursive: true, force: true })`. On a FUSE mount, unlinking a file that still has an open download fd recreates `.fuse_hidden*` entries, so delete never returns and the auto-delete timer is never armed.

This bounds directory deletion, isolates a stuck job so the rest still get removed, and always reschedules cleanup from `finally`.

Fixes #584

## Test plan

- [x] `bun test tests/helpers/rmBounded.test.ts tests/helpers/clearJobs.test.ts` (6 pass)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents job auto-delete from hanging on FUSE mounts by bounding directory removal and always rearming the cleanup timer. Previously unbounded `rmSync({ recursive: true, force: true })` could loop when FUSE recreated `.fuse_hidden*`; now deletion retries are capped, stuck jobs are isolated, and cleanup is rescheduled reliably.

- Introduces `rmBounded` (bounded recursive delete): ignores `ENOENT`, retries directory removal on `ENOTEMPTY` up to a limit, then throws to prevent infinite loops.
- Adds `clearExpiredJobs` and `startJobCleanup`: deletes output/uploads per job, removes the DB row only on successful deletes, logs and continues on failure, and reschedules from `finally` (with injectable `rm` and `schedule` for tests).
- Replaces the inline cleanup in `src/index.tsx` with `startJobCleanup` when `AUTO_DELETE_EVERY_N_HOURS > 0`.
- Tests cover FUSE behavior, real tree removal, missing-path tolerance, per-job isolation, and rescheduling on errors.

<sup>Written for commit 4daf77bd669ed1a56dfdd2ac8f76444b62cac284. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/C4illin/ConvertX/pull/618?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

