### PR TITLE
fix: hide the History link on the results and converters pages when HIDE_HISTORY is set

### DIFF
--- a/src/pages/listConverters.tsx
+++ b/src/pages/listConverters.tsx
@@ -2,7 +2,7 @@ import Elysia from "elysia";
 import { BaseHtml } from "../components/base";
 import { Header } from "../components/header";
 import { getAllInputs, getAllTargets } from "../converters/main";
-import { ALLOW_UNAUTHENTICATED, WEBROOT } from "../helpers/env";
+import { ALLOW_UNAUTHENTICATED, HIDE_HISTORY, WEBROOT } from "../helpers/env";
 import { userService } from "./user";
 
 export const listConverters = new Elysia().use(userService).get(
@@ -11,7 +11,12 @@ export const listConverters = new Elysia().use(userService).get(
     return (
       <BaseHtml webroot={WEBROOT} title="ConvertX | Converters">
         <>
-          <Header webroot={WEBROOT} allowUnauthenticated={ALLOW_UNAUTHENTICATED} loggedIn />
+          <Header
+            webroot={WEBROOT}
+            allowUnauthenticated={ALLOW_UNAUTHENTICATED}
+            hideHistory={HIDE_HISTORY}
+            loggedIn
+          />
           <main
             class={`
               w-full flex-1 px-2

--- a/src/pages/results.tsx
+++ b/src/pages/results.tsx
@@ -4,7 +4,7 @@ import { Header } from "../components/header";
 import db from "../db/db";
 import { Filename, Jobs } from "../db/types";
 import { buildDownloadUrl } from "../helpers/buildDownloadUrl";
-import { ALLOW_UNAUTHENTICATED, WEBROOT } from "../helpers/env";
+import { ALLOW_UNAUTHENTICATED, HIDE_HISTORY, WEBROOT } from "../helpers/env";
 import { DownloadIcon } from "../icons/download";
 import { DeleteIcon } from "../icons/delete";
 import { EyeIcon } from "../icons/eye";
@@ -163,7 +163,12 @@ export const results = new Elysia()
       return (
         <BaseHtml webroot={WEBROOT} title="ConvertX | Result">
           <>
-            <Header webroot={WEBROOT} allowUnauthenticated={ALLOW_UNAUTHENTICATED} loggedIn />
+            <Header
+              webroot={WEBROOT}
+              allowUnauthenticated={ALLOW_UNAUTHENTICATED}
+              hideHistory={HIDE_HISTORY}
+              loggedIn
+            />
             <main
               class={`
                 w-full flex-1 px-2

--- a/tests/pages/listConverters.test.ts
+++ b/tests/pages/listConverters.test.ts
@@ -1,0 +1,37 @@
+// The converters page is behind auth and reads HIDE_HISTORY at module load, so the
+// env is set and a valid session cookie is minted before the page is imported below.
+// The assertion is only about the header: with HIDE_HISTORY set, the History nav link
+// must not render on this page, which previously omitted the hideHistory prop.
+const JWT_SECRET = "test-secret";
+process.env.DB_PATH = ":memory:";
+process.env.JWT_SECRET = JWT_SECRET;
+process.env.HIDE_HISTORY = "true";
+
+import { createHmac } from "node:crypto";
+import { expect, test } from "bun:test";
+
+const { listConverters } = await import("../../src/pages/listConverters");
+
+// Minimal HS256 JWT so the authenticated route renders; @elysiajs/jwt verifies it.
+function sessionCookie(): string {
+  const b64url = (value: string) => Buffer.from(value).toString("base64url");
+  const payload = `${b64url(JSON.stringify({ alg: "HS256", typ: "JWT" }))}.${b64url(
+    JSON.stringify({ id: "1", exp: Math.floor(Date.now() / 1000) + 3600 }),
+  )}`;
+  const signature = createHmac("sha256", JWT_SECRET).update(payload).digest("base64url");
+  return `auth=${payload}.${signature}`;
+}
+
+// Regression test for #556.
+test("converters page hides the History link when HIDE_HISTORY is set", async () => {
+  const res = await listConverters.handle(
+    new Request("http://localhost/converters", { headers: { Cookie: sessionCookie() } }),
+  );
+  expect(res.status).toBe(200);
+
+  const html = await res.text();
+  // Sanity: the authenticated header actually rendered.
+  expect(html).toContain('href="/account"');
+  // The History link must be gone.
+  expect(html).not.toContain('href="/history"');
+});

--- a/tests/pages/listConverters.test.ts
+++ b/tests/pages/listConverters.test.ts
@@ -6,6 +6,7 @@ const JWT_SECRET = "test-secret";
 process.env.DB_PATH = ":memory:";
 process.env.JWT_SECRET = JWT_SECRET;
 process.env.HIDE_HISTORY = "true";
+process.env.WEBROOT = "";
 
 import { createHmac } from "node:crypto";
 import { expect, test } from "bun:test";

--- a/tests/pages/results.test.ts
+++ b/tests/pages/results.test.ts
@@ -1,5 +1,18 @@
+// The results page is behind auth and reads HIDE_HISTORY at module load, so the env is
+// set and a session cookie minted before the page is imported below. buildDownloadUrl
+// has no env dependency, so importing it statically above is safe.
+const JWT_SECRET = "test-secret";
+process.env.DB_PATH = ":memory:";
+process.env.JWT_SECRET = JWT_SECRET;
+process.env.HIDE_HISTORY = "true";
+process.env.WEBROOT = "";
+
+import { createHmac } from "node:crypto";
 import { expect, test } from "bun:test";
 import { buildDownloadUrl } from "../../src/helpers/buildDownloadUrl";
+
+const { default: db } = await import("../../src/db/db");
+const { results } = await import("../../src/pages/results");
 
 test("encodes reserved characters in download filenames", () => {
   expect(buildDownloadUrl("", "1/2/", "clip #1?.gif")).toBe("/download/1/2/clip%20%231%3F.gif");
@@ -9,4 +22,34 @@ test("preserves output path segments while encoding the filename", () => {
   expect(buildDownloadUrl("/convertx", "user/job/", "報告 100%.pdf")).toBe(
     "/convertx/download/user/job/%E5%A0%B1%E5%91%8A%20100%25.pdf",
   );
+});
+
+// Minimal HS256 JWT so the authenticated route renders; @elysiajs/jwt verifies it.
+function sessionCookie(): string {
+  const b64url = (value: string) => Buffer.from(value).toString("base64url");
+  const payload = `${b64url(JSON.stringify({ alg: "HS256", typ: "JWT" }))}.${b64url(
+    JSON.stringify({ id: "1", exp: Math.floor(Date.now() / 1000) + 3600 }),
+  )}`;
+  const signature = createHmac("sha256", JWT_SECRET).update(payload).digest("base64url");
+  return `auth=${payload}.${signature}`;
+}
+
+// Regression test for #556 on the results page (the scenario in the report: the header
+// shown right after a conversion). Previously this page omitted the hideHistory prop.
+test("results page hides the History link when HIDE_HISTORY is set", async () => {
+  db.query("INSERT INTO users (id, email, password) VALUES (1, 'test@example.com', 'x')").run();
+  db.query(
+    "INSERT INTO jobs (id, user_id, date_created, status, num_files) VALUES (1, 1, '2026-01-01', 'done', 0)",
+  ).run();
+
+  const res = await results.handle(
+    new Request("http://localhost/results/1", { headers: { Cookie: sessionCookie() } }),
+  );
+  expect(res.status).toBe(200);
+
+  const html = await res.text();
+  // Sanity: the authenticated header actually rendered.
+  expect(html).toContain('href="/account"');
+  // The History link must be gone.
+  expect(html).not.toContain('href="/history"');
 });


### PR DESCRIPTION
## Summary

When `HIDE_HISTORY=true`, the History nav link is hidden on most pages but still showed on two: the conversion results page and the converters list page. Both rendered `<Header>` without the `hideHistory` prop, so it defaulted to visible. The results page is the one seen in #556, right after a conversion completes.

Every other page that renders the logged-in header (`root.tsx`, `history.tsx`, `user.tsx`) already passes `hideHistory={HIDE_HISTORY}`. This does the same on `results.tsx` and `listConverters.tsx`, so the setting is respected everywhere.

Resolves #556

## Changes

- `src/pages/results.tsx`: pass `hideHistory={HIDE_HISTORY}` to `<Header>` (and import it).
- `src/pages/listConverters.tsx`: same.
- `tests/pages/listConverters.test.ts`: regression test that renders the converters page with `HIDE_HISTORY=true` and asserts the History link is absent. It fails without the fix.

## Testing

- `bun test` passes, including the new test. With the `listConverters` change reverted, the new test fails on the `href="/history"` assertion, so it genuinely guards the fix.
- `bun run lint` is clean (tsc, eslint, prettier, knip, xss-scan).
