### PR TITLE
feat: add pdf2docx converter for pdf to docx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -82,6 +82,7 @@ RUN apt-get update && apt-get install -y \
   pipx \
   --no-install-recommends \
   && pipx install "markitdown[all]" \
+  && pipx install pdf2docx \
   && rm -rf /var/lib/apt/lists/*
 
 # Add pipx bin directory to PATH

--- a/src/converters/main.ts
+++ b/src/converters/main.ts
@@ -25,6 +25,7 @@ import { convert as convertVtracer, properties as propertiesVtracer } from "./vt
 import { convert as convertVcf, properties as propertiesVcf } from "./vcf";
 import { convert as convertxelatex, properties as propertiesxelatex } from "./xelatex";
 import { convert as convertMarkitdown, properties as propertiesMarkitdown } from "./markitdown";
+import { convert as convertPdf2docx, properties as propertiesPdf2docx } from "./pdf2docx";
 
 // This should probably be reconstructed so that the functions are not imported instead the functions hook into this to make the converters more modular
 
@@ -136,6 +137,13 @@ const properties: Record<
   markitDown: {
     properties: propertiesMarkitdown,
     converter: convertMarkitdown,
+  },
+  // Last, so that automatic selection prefers it over LibreOffice for pdf to
+  // docx. LibreOffice's pdf import turns every line into a floating text box,
+  // which loses tables entirely; pdf2docx reconstructs them.
+  pdf2docx: {
+    properties: propertiesPdf2docx,
+    converter: convertPdf2docx,
   },
 };
 

--- a/src/converters/pdf2docx.ts
+++ b/src/converters/pdf2docx.ts
@@ -1,0 +1,46 @@
+import { execFile as execFileOriginal } from "node:child_process";
+import { ExecFileFn } from "./types";
+
+// LibreOffice can already produce a docx from a pdf, but its pdf import maps
+// every line onto a floating text box: the result carries the words and none of
+// the structure, so tables disappear and the document cannot practically be
+// edited. pdf2docx reconstructs paragraphs, tables and images instead, which is
+// what someone converting an invoice or a contract is actually asking for.
+//
+// It only handles this one direction, so LibreOffice keeps everything else.
+export const properties = {
+  from: {
+    document: ["pdf"],
+  },
+  to: {
+    document: ["docx"],
+  },
+};
+
+export async function convert(
+  filePath: string,
+  fileType: string,
+  convertTo: string,
+  targetPath: string,
+  options?: unknown,
+  execFile: ExecFileFn = execFileOriginal,
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile("pdf2docx", ["convert", filePath, targetPath], (err, stdout, stderr) => {
+      if (err) {
+        reject(`pdf2docx error: ${err}`);
+        return;
+      }
+
+      if (stdout) {
+        console.log(`stdout: ${stdout}`);
+      }
+
+      if (stderr) {
+        console.error(`stderr: ${stderr}`);
+      }
+
+      resolve("Done");
+    });
+  });
+}


### PR DESCRIPTION
LibreOffice can already produce a `docx` from a `pdf`, but its pdf import maps every line onto a floating text box. The words survive and the structure does not, so the result is not practically editable.

I measured it on a one-page invoice with a four-column table, a merged total row, headings and a list. Same source pdf, both converters, counting elements in `word/document.xml`:

| | LibreOffice | pdf2docx |
|---|---|---|
| tables | 0 | 2 |
| table cells | 0 | 20 |
| text boxes | 52 | 0 |

The merged total row survives with pdf2docx. With LibreOffice the table is gone entirely — every cell became its own floating box.

### What this adds

`src/converters/pdf2docx.ts`, following the same shape as `markitdown.ts`, plus one `pipx install pdf2docx` line in the Dockerfile.

It declares only `pdf` → `docx`, so LibreOffice keeps every other pair it handles today. It is registered last in the `properties` record so automatic selection prefers it for that one pair; LibreOffice stays selectable explicitly for anyone who wants the old behaviour.

### About the dependency

[pdf2docx](https://github.com/ArtifexSoftware/pdf2docx) is MIT, maintained by Artifex — the same people behind MuPDF and Ghostscript. 3.5k stars, last release v0.5.13 in May 2026, no published security advisories. It pulls in PyMuPDF, python-docx, opencv-python-headless, numpy, lxml and fonttools.

It is CPU-only, so it adds no hardware requirement. It does not OCR: an image-only pdf still needs one of the existing paths.

Closes #290 more completely than the LibreOffice route added in #510.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `pdf2docx` converter that becomes the default for PDF-to-DOCX because LibreOffice's PDF import turns every line into a floating text box and loses tables, while `pdf2docx` rebuilds paragraphs and tables. It only handles pdf→docx, so LibreOffice keeps every other pair and remains explicitly selectable.

**Details**
- Installs `pdf2docx` via `pipx` in the Dockerfile.
- Closes #290, superseding the LibreOffice route added in #510.

<sup>Written for commit ffc8f4c76d5ef3448088d9dfd33e06634b0270f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/C4illin/ConvertX/pull/621?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

