### PR TITLE
fix(results): hide actions for failed conversions

### DIFF
--- a/src/pages/download.tsx
+++ b/src/pages/download.tsx
@@ -11,7 +11,7 @@ export const download = new Elysia()
   .use(userService)
   .get(
     "/download/:userId/:jobId/:fileName",
-    async ({ params, redirect, user }) => {
+    async ({ params, redirect, set, user }) => {
       const userId = user.id;
       const job = await db
         .query("SELECT * FROM jobs WHERE user_id = ? AND id = ?")
@@ -25,7 +25,13 @@ export const download = new Elysia()
       const fileName = sanitize(decodeURIComponent(params.fileName));
 
       const filePath = `${outputDir}${userId}/${jobId}/${fileName}`;
-      return Bun.file(filePath);
+      const file = Bun.file(filePath);
+      if (!(await file.exists())) {
+        set.status = 404;
+        return { message: "Converted file not found." };
+      }
+
+      return file;
     },
     {
       auth: true,

--- a/src/pages/results.tsx
+++ b/src/pages/results.tsx
@@ -96,35 +96,47 @@ function ResultsArticle({
           </tr>
         </thead>
         <tbody>
-          {files.map((file) => (
-            <tr>
-              <td safe class="max-w-[20vw] truncate">
-                {file.output_file_name}
-              </td>
-              <td safe>{file.status}</td>
-              <td class="flex flex-row gap-4">
-                <a
-                  class={`
-                    text-accent-500 underline
-                    hover:text-accent-400
-                  `}
-                  href={buildDownloadUrl(WEBROOT, outputPath, file.output_file_name)}
-                >
-                  <EyeIcon />
-                </a>
-                <a
-                  class={`
-                    text-accent-500 underline
-                    hover:text-accent-400
-                  `}
-                  href={buildDownloadUrl(WEBROOT, outputPath, file.output_file_name)}
-                  download={file.output_file_name}
-                >
-                  <DownloadIcon />
-                </a>
-              </td>
-            </tr>
-          ))}
+          {files.map((file) => {
+            const conversionFailed = ["Failed, check logs", "File type not supported"].includes(
+              file.status,
+            );
+
+            return (
+              <tr>
+                <td safe class="max-w-[20vw] truncate">
+                  {file.output_file_name}
+                </td>
+                <td safe>{file.status}</td>
+                <td class="flex flex-row gap-4">
+                  {conversionFailed ? (
+                    <span class="text-neutral-500">Unavailable</span>
+                  ) : (
+                    <>
+                      <a
+                        class={`
+                          text-accent-500 underline
+                          hover:text-accent-400
+                        `}
+                        href={buildDownloadUrl(WEBROOT, outputPath, file.output_file_name)}
+                      >
+                        <EyeIcon />
+                      </a>
+                      <a
+                        class={`
+                          text-accent-500 underline
+                          hover:text-accent-400
+                        `}
+                        href={buildDownloadUrl(WEBROOT, outputPath, file.output_file_name)}
+                        download={file.output_file_name}
+                      >
+                        <DownloadIcon />
+                      </a>
+                    </>
+                  )}
+                </td>
+              </tr>
+            );
+          })}
         </tbody>
       </table>
     </article>


### PR DESCRIPTION
### Before, if a file conversion failed the results page would still show view and download links. Clicking either would present the user with a useless error (it's failing to find the converted file, not actually telling the user why the conversion failed) or opaquely fail to download.
<img width="958" height="296" alt="image" src="https://github.com/user-attachments/assets/5d6464c6-5759-4e3f-9cac-179985b77e24" />
<img width="676" height="280" alt="image" src="https://github.com/user-attachments/assets/5b345f96-b07c-4e99-9e24-cae66e72e474" />
<img width="317" height="75" alt="image" src="https://github.com/user-attachments/assets/df36948c-6f5e-4282-bf39-1083f82a9bc7" />

### With this fix, there are no available actions for a failed conversion.
<img width="924" height="264" alt="image" src="https://github.com/user-attachments/assets/6458b5d3-f8c5-44e2-9cfe-d98c80ac44a2" />



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hides view and download actions for failed conversions in the results page. Failed conversions now show "Unavailable" instead of links that led to confusing errors or silent download failures.

The download endpoint now returns a 404 with a clear message when the converted file doesn't exist.

<sup>Written for commit 74feaee580894d573f099a7b8f9b26c0a98ade92. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/C4illin/ConvertX/pull/625?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

