### PR TITLE
feat(upload): support pasting clipboard files

### DIFF
--- a/public/mime-types.js
+++ b/public/mime-types.js
@@ -1,0 +1,51 @@
+const mimeTypeExtensions = {
+  "application/epub+zip": "epub",
+  "application/json": "json",
+  "application/msword": "doc",
+  "application/pdf": "pdf",
+  "application/rtf": "rtf",
+  "application/vnd.ms-excel": "xls",
+  "application/vnd.ms-powerpoint": "ppt",
+  "application/vnd.oasis.opendocument.presentation": "odp",
+  "application/vnd.oasis.opendocument.spreadsheet": "ods",
+  "application/vnd.oasis.opendocument.text": "odt",
+  "application/vnd.openxmlformats-officedocument.presentationml.presentation": "pptx",
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": "xlsx",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document": "docx",
+  "application/x-yaml": "yaml",
+  "application/xml": "xml",
+  "application/zip": "zip",
+  "image/jpeg": "jpg",
+  "image/pjpeg": "jpg",
+  "image/svg+xml": "svg",
+  "image/tiff": "tif",
+  "image/vnd.adobe.photoshop": "psd",
+  "image/vnd.djvu": "djvu",
+  "image/vnd.dwg": "dwg",
+  "image/vnd.dxf": "dxf",
+  "image/vnd.microsoft.icon": "ico",
+  "image/x-icon": "ico",
+  "text/csv": "csv",
+  "text/html": "html",
+  "text/markdown": "md",
+  "text/plain": "txt",
+  "text/xml": "xml",
+  "text/yaml": "yaml",
+};
+
+window.inferExtensionFromMimeType = (type) => {
+  const normalizedType = type.toLowerCase();
+  // If it's a known MIME type, return the extension.
+  if (mimeTypeExtensions[normalizedType]) {
+    return mimeTypeExtensions[normalizedType];
+  }
+
+  // If it's a yet-unhandled `image/*` MIME type, return the subtype.
+  const [mediaType, subtype] = normalizedType.split("/");
+  if (mediaType === "image" && subtype && !subtype.startsWith("vnd.")) {
+    return subtype.split("+")[0];
+  }
+
+  // Use `.bin` if we don't know what to do.
+  return "bin";
+};

--- a/public/script.js
+++ b/public/script.js
@@ -33,6 +33,69 @@ dropZone.addEventListener("drop", (e) => {
   }
 });
 
+const inferExtensionFromMimeType = (type) => {
+  const extensions = {
+    "application/epub+zip": "epub",
+    "application/json": "json",
+    "application/msword": "doc",
+    "application/pdf": "pdf",
+    "application/rtf": "rtf",
+    "application/vnd.ms-excel": "xls",
+    "application/vnd.ms-powerpoint": "ppt",
+    "application/vnd.oasis.opendocument.presentation": "odp",
+    "application/vnd.oasis.opendocument.spreadsheet": "ods",
+    "application/vnd.oasis.opendocument.text": "odt",
+    "application/vnd.openxmlformats-officedocument.presentationml.presentation": "pptx",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": "xlsx",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document": "docx",
+    "application/x-yaml": "yaml",
+    "application/xml": "xml",
+    "application/zip": "zip",
+    "image/jpeg": "jpg",
+    "image/svg+xml": "svg",
+    "image/tiff": "tif",
+    "image/x-icon": "ico",
+    "text/csv": "csv",
+    "text/html": "html",
+    "text/markdown": "md",
+    "text/plain": "txt",
+    "text/xml": "xml",
+    "text/yaml": "yaml",
+  };
+
+  return extensions[type] ?? "bin";
+};
+
+const generatePastedFilename = (file) => {
+  if (file.name && file.name.includes(".")) {
+    return file.name;
+  }
+
+  const extension = inferExtensionFromMimeType(file.type);
+  const timestamp = new Date().toISOString().replaceAll(":", "-").replace("Z", "");
+  return `clipboard-file-${timestamp}.${extension}`;
+};
+
+// Listen for pastes and handle files if any are present.
+document.addEventListener("paste", (e) => {
+  const files = Array.from(e.clipboardData?.files ?? []);
+
+  if (files.length === 0) {
+    return;
+  }
+
+  e.preventDefault();
+
+  for (const file of files) {
+    const namedFile = new File([file], generatePastedFilename(file), {
+      type: file.type,
+      lastModified: file.lastModified,
+    });
+    console.log("Handling pasted file:", namedFile.name);
+    handleFile(namedFile);
+  }
+});
+
 // Extracted handleFile function for reusability in drag-and-drop and file input
 function handleFile(file) {
   const fileList = document.querySelector("#file-list");

--- a/public/script.js
+++ b/public/script.js
@@ -52,8 +52,10 @@ const inferExtensionFromMimeType = (type) => {
     "application/xml": "xml",
     "application/zip": "zip",
     "image/jpeg": "jpg",
+    "image/pjpeg": "jpg",
     "image/svg+xml": "svg",
     "image/tiff": "tif",
+    "image/vnd.microsoft.icon": "ico",
     "image/x-icon": "ico",
     "text/csv": "csv",
     "text/html": "html",
@@ -63,17 +65,29 @@ const inferExtensionFromMimeType = (type) => {
     "text/yaml": "yaml",
   };
 
-  return extensions[type] ?? "bin";
+  if (extensions[type]) {
+    return extensions[type];
+  }
+
+  // If it's a yet-unhandled `image/*` MIME type, return the subtype.
+  const [mediaType, subtype] = type.toLowerCase().split("/");
+  if (mediaType === "image" && subtype) {
+    return subtype.split("+")[0];
+  }
+
+  // Use `.bin` if we don't know what to do.
+  return "bin";
 };
 
-const generatePastedFilename = (file) => {
+const generatePastedFilename = (sequenceNumber, file) => {
+  // If the file has a name and it includes a period, use the name.
   if (file.name && file.name.includes(".")) {
     return file.name;
   }
 
   const extension = inferExtensionFromMimeType(file.type);
   const timestamp = new Date().toISOString().replaceAll(":", "-").replace("Z", "");
-  return `clipboard-file-${timestamp}.${extension}`;
+  return `clipboard-file-${timestamp}-${sequenceNumber}.${extension}`;
 };
 
 // Listen for pastes and handle files if any are present.
@@ -86,11 +100,12 @@ document.addEventListener("paste", (e) => {
 
   e.preventDefault();
 
-  for (const file of files) {
-    const namedFile = new File([file], generatePastedFilename(file), {
+  for (const [sequenceNumber, file] of files.entries()) {
+    const namedFile = new File([file], generatePastedFilename(sequenceNumber, file), {
       type: file.type,
       lastModified: file.lastModified,
     });
+
     console.log("Handling pasted file:", namedFile.name);
     handleFile(namedFile);
   }
@@ -102,11 +117,12 @@ function handleFile(file) {
 
   const row = document.createElement("tr");
   row.innerHTML = `
-    <td>${file.name}</td>
+    <td></td>
     <td><progress max="100" class="inline-block h-2 appearance-none overflow-hidden rounded-full border-0 bg-neutral-700 bg-none text-accent-500 accent-accent-500 [&::-moz-progress-bar]:bg-accent-500 [&::-webkit-progress-value]:rounded-full [&::-webkit-progress-value]:[background:none] [&[value]::-webkit-progress-value]:bg-accent-500 [&[value]::-webkit-progress-value]:transition-[inline-size]"></progress></td>
     <td>${(file.size / 1024).toFixed(2)} kB</td>
     <td><button type="button" class="text-accent-500 hover:underline" onclick="deleteRow(this)">Remove</button></td>
   `;
+  row.firstElementChild.textContent = file.name;
 
   if (!fileType) {
     fileType = file.name.split(".").pop();

--- a/public/script.js
+++ b/public/script.js
@@ -33,59 +33,13 @@ dropZone.addEventListener("drop", (e) => {
   }
 });
 
-const inferExtensionFromMimeType = (type) => {
-  const extensions = {
-    "application/epub+zip": "epub",
-    "application/json": "json",
-    "application/msword": "doc",
-    "application/pdf": "pdf",
-    "application/rtf": "rtf",
-    "application/vnd.ms-excel": "xls",
-    "application/vnd.ms-powerpoint": "ppt",
-    "application/vnd.oasis.opendocument.presentation": "odp",
-    "application/vnd.oasis.opendocument.spreadsheet": "ods",
-    "application/vnd.oasis.opendocument.text": "odt",
-    "application/vnd.openxmlformats-officedocument.presentationml.presentation": "pptx",
-    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": "xlsx",
-    "application/vnd.openxmlformats-officedocument.wordprocessingml.document": "docx",
-    "application/x-yaml": "yaml",
-    "application/xml": "xml",
-    "application/zip": "zip",
-    "image/jpeg": "jpg",
-    "image/pjpeg": "jpg",
-    "image/svg+xml": "svg",
-    "image/tiff": "tif",
-    "image/vnd.microsoft.icon": "ico",
-    "image/x-icon": "ico",
-    "text/csv": "csv",
-    "text/html": "html",
-    "text/markdown": "md",
-    "text/plain": "txt",
-    "text/xml": "xml",
-    "text/yaml": "yaml",
-  };
-
-  if (extensions[type]) {
-    return extensions[type];
-  }
-
-  // If it's a yet-unhandled `image/*` MIME type, return the subtype.
-  const [mediaType, subtype] = type.toLowerCase().split("/");
-  if (mediaType === "image" && subtype) {
-    return subtype.split("+")[0];
-  }
-
-  // Use `.bin` if we don't know what to do.
-  return "bin";
-};
-
 const generatePastedFilename = (sequenceNumber, file) => {
   // If the file has a name and it includes a period, use the name.
   if (file.name && file.name.includes(".")) {
     return file.name;
   }
 
-  const extension = inferExtensionFromMimeType(file.type);
+  const extension = window.inferExtensionFromMimeType(file.type);
   const timestamp = new Date().toISOString().replaceAll(":", "-").replace("Z", "");
   return `clipboard-file-${timestamp}-${sequenceNumber}.${extension}`;
 };

--- a/src/pages/root.tsx
+++ b/src/pages/root.tsx
@@ -143,7 +143,7 @@ export const root = new Elysia().use(userService).get(
                 `}
               >
                 <span>
-                  <b>Choose a file</b> or drag it here
+                  <b>Click to choose a file</b>, drag it here, or paste it.
                 </span>
                 <input
                   type="file"

--- a/src/pages/root.tsx
+++ b/src/pages/root.tsx
@@ -236,7 +236,8 @@ export const root = new Elysia().use(userService).get(
               />
             </form>
           </main>
-          <script src="script.js" defer />
+          <script src={`${WEBROOT}/mime-types.js`} defer />
+          <script src={`${WEBROOT}/script.js`} defer />
         </>
       </BaseHtml>
     );


### PR DESCRIPTION
### Adds a paste event listener which infers files types for files based on their MIME type, or takes the existing name if it has one already.
<img width="924" height="309" alt="image" src="https://github.com/user-attachments/assets/94be9bb5-1d98-4886-acc1-5da620d6186b" />
<img width="921" height="360" alt="image" src="https://github.com/user-attachments/assets/85b0086c-e035-4095-ae91-872fc34143bf" />
<img width="525" height="84" alt="image" src="https://github.com/user-attachments/assets/d57d79ea-690d-41a6-a18f-c11f2820ea1e" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for pasting files from the clipboard in the upload drop zone, with hardened filename and MIME type handling.

- Listens for paste events and handles any files found in the clipboard.
- Keeps a pasted file's name when it includes an extension; otherwise generates a timestamped name from its MIME type, falling back to `.bin`.
- Renders file names as plain text to prevent HTML injection.
- Updates the drop zone hint to mention pasting as an option.

<sup>Written for commit a0910485ff4f2c2e9eb44a7f4466554c945046ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/C4illin/ConvertX/pull/626?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

