### PR TITLE
feat(auth): autofocus login email field

### DIFF
--- a/src/pages/user.tsx
+++ b/src/pages/user.tsx
@@ -279,6 +279,7 @@ export const user = new Elysia()
                         class="rounded-sm bg-neutral-800 p-3"
                         placeholder="Email"
                         autocomplete="email"
+                        autofocus
                         required
                       />
                     </label>


### PR DESCRIPTION
This is a small quality-of-life improvement. When you open the login page, this allows you to immediately start typing your username.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds autofocus to the login email field so users can start typing immediately without clicking the input first.

<sup>Written for commit 0c8481164263097447a9d2de75cf3bdfa38c6f36. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/C4illin/ConvertX/pull/627?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

