### PR TITLE
fix(auth): redirect unauthorized page requests

### DIFF
--- a/src/helpers/isHtmlPageRequest.ts
+++ b/src/helpers/isHtmlPageRequest.ts
@@ -1,4 +1,4 @@
 export function isHtmlPageRequest(request: Request): boolean {
-  const acceptsHtml = request.headers.get("accept")?.includes("text/html");
+  const acceptsHtml = request.headers.get("accept")?.toLowerCase().includes("text/html");
   return (request.method === "GET" || request.method === "HEAD") && Boolean(acceptsHtml);
 }

--- a/src/helpers/isHtmlPageRequest.ts
+++ b/src/helpers/isHtmlPageRequest.ts
@@ -1,0 +1,4 @@
+export function isHtmlPageRequest(request: Request): boolean {
+  const acceptsHtml = request.headers.get("accept")?.includes("text/html");
+  return (request.method === "GET" || request.method === "HEAD") && Boolean(acceptsHtml);
+}

--- a/src/pages/user.tsx
+++ b/src/pages/user.tsx
@@ -1,5 +1,3 @@
-import { randomUUID } from "node:crypto";
-import { jwt } from "@elysiajs/jwt";
 import { Elysia, t } from "elysia";
 import { BaseHtml } from "../components/base";
 import { Header } from "../components/header";
@@ -12,67 +10,11 @@ import {
   HTTP_ALLOWED,
   WEBROOT,
 } from "../helpers/env";
-import { isHtmlPageRequest } from "../helpers/isHtmlPageRequest";
+import { userService } from "../services/user";
+
+export { userService } from "../services/user";
 
 export let FIRST_RUN = db.query("SELECT * FROM users").get() === null || false;
-
-export const userService = new Elysia({ name: "user/service" })
-  .use(
-    jwt({
-      name: "jwt",
-      schema: t.Object({
-        id: t.String(),
-      }),
-      secret: process.env.JWT_SECRET ?? randomUUID(),
-      exp: "7d",
-    }),
-  )
-  .model({
-    signIn: t.Object({
-      email: t.String(),
-      password: t.String(),
-    }),
-    session: t.Cookie({
-      auth: t.String(),
-      jobId: t.Optional(t.String()),
-    }),
-    optionalSession: t.Cookie({
-      auth: t.Optional(t.String()),
-      jobId: t.Optional(t.String()),
-    }),
-  })
-  .macro("auth", {
-    cookie: "optionalSession",
-    async resolve({ request, set, status, jwt, cookie: { auth } }) {
-      const unauthorized = () => {
-        if (isHtmlPageRequest(request)) {
-          set.headers.location = `${WEBROOT}/login`;
-          return status(302, {
-            success: false,
-            message: "Redirecting to login",
-          });
-        }
-
-        return status(401, {
-          success: false,
-          message: "Unauthorized",
-        });
-      };
-
-      if (!auth.value) {
-        return unauthorized();
-      }
-      const user = await jwt.verify(auth.value);
-      if (!user) {
-        auth.remove();
-        return unauthorized();
-      }
-      return {
-        success: true,
-        user,
-      };
-    },
-  });
 
 export const user = new Elysia()
   .use(userService)

--- a/src/pages/user.tsx
+++ b/src/pages/user.tsx
@@ -12,6 +12,7 @@ import {
   HTTP_ALLOWED,
   WEBROOT,
 } from "../helpers/env";
+import { isHtmlPageRequest } from "../helpers/isHtmlPageRequest";
 
 export let FIRST_RUN = db.query("SELECT * FROM users").get() === null || false;
 
@@ -41,20 +42,30 @@ export const userService = new Elysia({ name: "user/service" })
     }),
   })
   .macro("auth", {
-    cookie: "session",
-    async resolve({ status, jwt, cookie: { auth } }) {
-      if (!auth.value) {
+    cookie: "optionalSession",
+    async resolve({ request, set, status, jwt, cookie: { auth } }) {
+      const unauthorized = () => {
+        if (isHtmlPageRequest(request)) {
+          set.headers.location = `${WEBROOT}/login`;
+          return status(302, {
+            success: false,
+            message: "Redirecting to login",
+          });
+        }
+
         return status(401, {
           success: false,
           message: "Unauthorized",
         });
+      };
+
+      if (!auth.value) {
+        return unauthorized();
       }
       const user = await jwt.verify(auth.value);
       if (!user) {
-        return status(401, {
-          success: false,
-          message: "Unauthorized",
-        });
+        auth.remove();
+        return unauthorized();
       }
       return {
         success: true,

--- a/src/services/user.ts
+++ b/src/services/user.ts
@@ -1,0 +1,63 @@
+import { randomUUID } from "node:crypto";
+import { jwt } from "@elysiajs/jwt";
+import { Elysia, t } from "elysia";
+import { WEBROOT } from "../helpers/env";
+import { isHtmlPageRequest } from "../helpers/isHtmlPageRequest";
+
+export const userService = new Elysia({ name: "user/service" })
+  .use(
+    jwt({
+      name: "jwt",
+      schema: t.Object({
+        id: t.String(),
+      }),
+      secret: process.env.JWT_SECRET ?? randomUUID(),
+      exp: "7d",
+    }),
+  )
+  .model({
+    signIn: t.Object({
+      email: t.String(),
+      password: t.String(),
+    }),
+    session: t.Cookie({
+      auth: t.String(),
+      jobId: t.Optional(t.String()),
+    }),
+    optionalSession: t.Cookie({
+      auth: t.Optional(t.String()),
+      jobId: t.Optional(t.String()),
+    }),
+  })
+  .macro("auth", {
+    cookie: "optionalSession",
+    async resolve({ request, set, status, jwt, cookie: { auth } }) {
+      const unauthorized = () => {
+        if (isHtmlPageRequest(request)) {
+          set.headers.location = `${WEBROOT}/login`;
+          return status(302, {
+            success: false,
+            message: "Redirecting to login",
+          });
+        }
+
+        return status(401, {
+          success: false,
+          message: "Unauthorized",
+        });
+      };
+
+      if (!auth.value) {
+        return unauthorized();
+      }
+      const user = await jwt.verify(auth.value);
+      if (!user) {
+        auth.remove();
+        return unauthorized();
+      }
+      return {
+        success: true,
+        user,
+      };
+    },
+  });

--- a/tests/pages/auth.test.ts
+++ b/tests/pages/auth.test.ts
@@ -1,0 +1,48 @@
+import { expect, test } from "bun:test";
+import { isHtmlPageRequest } from "../../src/helpers/isHtmlPageRequest";
+
+test("identifies HTML page navigation requests", () => {
+  expect(
+    isHtmlPageRequest(
+      new Request("http://localhost/protected", {
+        headers: { accept: "text/html" },
+      }),
+    ),
+  ).toBe(true);
+
+  expect(
+    isHtmlPageRequest(
+      new Request("http://localhost/protected", {
+        method: "HEAD",
+        headers: { accept: "text/html,application/xhtml+xml" },
+      }),
+    ),
+  ).toBe(true);
+});
+
+test("does not identify API requests as HTML page navigation", () => {
+  expect(
+    isHtmlPageRequest(
+      new Request("http://localhost/protected", {
+        method: "POST",
+        headers: { accept: "text/html" },
+      }),
+    ),
+  ).toBe(false);
+
+  expect(
+    isHtmlPageRequest(
+      new Request("http://localhost/protected", {
+        headers: { accept: "application/json" },
+      }),
+    ),
+  ).toBe(false);
+
+  expect(
+    isHtmlPageRequest(
+      new Request("http://localhost/protected", {
+        headers: { accept: "*/*" },
+      }),
+    ),
+  ).toBe(false);
+});

--- a/tests/pages/auth.test.ts
+++ b/tests/pages/auth.test.ts
@@ -1,11 +1,26 @@
 import { expect, test } from "bun:test";
+import { Elysia } from "elysia";
 import { isHtmlPageRequest } from "../../src/helpers/isHtmlPageRequest";
+import { userService } from "../../src/services/user";
+
+const app = new Elysia()
+  .use(userService)
+  .get("/protected", () => "protected", { auth: true })
+  .post("/protected", () => "protected", { auth: true });
 
 test("identifies HTML page navigation requests", () => {
   expect(
     isHtmlPageRequest(
       new Request("http://localhost/protected", {
         headers: { accept: "text/html" },
+      }),
+    ),
+  ).toBe(true);
+
+  expect(
+    isHtmlPageRequest(
+      new Request("http://localhost/protected", {
+        headers: { accept: "TEXT/HTML" },
       }),
     ),
   ).toBe(true);
@@ -45,4 +60,28 @@ test("does not identify API requests as HTML page navigation", () => {
       }),
     ),
   ).toBe(false);
+});
+
+test("redirects unauthorized HTML requests to login", async () => {
+  const response = await app.handle(
+    new Request("http://localhost/protected", {
+      headers: { accept: "text/html" },
+      redirect: "manual",
+    }),
+  );
+
+  expect(response.status).toBe(302);
+  expect(response.headers.get("location")).toBe("/login");
+});
+
+test("returns JSON 401 for unauthorized API requests", async () => {
+  const response = await app.handle(
+    new Request("http://localhost/protected", {
+      method: "POST",
+      headers: { accept: "application/json" },
+    }),
+  );
+
+  expect(response.status).toBe(401);
+  expect(await response.json()).toEqual({ success: false, message: "Unauthorized" });
 });


### PR DESCRIPTION
Instead of printing the 401 error's JSON when accessing an unauthorized page (e.g. `/results/21` without an active session)

<img width="321" height="67" alt="image" src="https://github.com/user-attachments/assets/3335dd6d-643d-4b89-94c3-01cd66d03edc" />

This updates the auth handler to distinguish between page navigation (HTML request) and API requests.
* Unauthorized API requests get a 401 error.
* Unauthorizedpage naviation gets a 302 redirect back to `/login`

This PR also adds a test to cover the API vs page navigation logic.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redirects unauthorized page navigation to `/login` instead of showing the 401 JSON error, while API requests still get 401 responses.

- Adds an `isHtmlPageRequest` helper that detects HTML navigation via GET/HEAD requests whose accept header includes `text/html` (case-insensitive).
- Clears an invalid session cookie before redirecting.
- Adds tests covering page navigation and API request detection.

<sup>Written for commit bbd2f2126e8bfc7267c047b199eb08a8ce0a2615. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/C4illin/ConvertX/pull/628?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

