### PR TITLE
fix(ffmpeg): raise execFile maxBuffer so long conversions don't overflow stderr

### DIFF
--- a/src/converters/ffmpeg.ts
+++ b/src/converters/ffmpeg.ts
@@ -1,5 +1,22 @@
-import { execFile as execFileOriginal } from "node:child_process";
-import { ExecFileFn } from "./types";
+import {
+  execFile as execFileOriginal,
+  type ChildProcess,
+  type ExecFileOptions,
+} from "node:child_process";
+
+// ffmpeg streams continuous progress to stderr, so a long conversion overflows
+// execFile's 1 MB default maxBuffer and fails with "stderr maxBuffer length
+// exceeded" (issue #565). Raise it well above that. The options object must be
+// passed before the callback: execFile ignores an options argument placed after
+// the callback, which is why the shared ExecFileFn type cannot carry it.
+const FFMPEG_MAX_BUFFER = 1024 * 1024 * 64; // 64 MB
+
+type FfmpegExecFile = (
+  cmd: string,
+  args: string[],
+  options: ExecFileOptions,
+  callback: (err: Error | null, stdout: string, stderr: string) => void,
+) => ChildProcess | void;
 
 // This could be done dynamically by running `ffmpeg -formats` and parsing the output
 export const properties = {
@@ -694,7 +711,7 @@ export async function convert(
   convertTo: string,
   targetPath: string,
   options?: unknown,
-  execFile: ExecFileFn = execFileOriginal, // to make it mockable
+  execFile: FfmpegExecFile = execFileOriginal as FfmpegExecFile, // to make it mockable
 ): Promise<string> {
   let extraArgs: string[] = [];
   let message = "Done";
@@ -739,6 +756,7 @@ export async function convert(
     execFile(
       "ffmpeg",
       [...ffmpegArgs, "-i", filePath, ...ffmpegOutputArgs, ...extraArgs, targetPath],
+      { maxBuffer: FFMPEG_MAX_BUFFER },
       (error, stdout, stderr) => {
         if (error) {
           reject(`error: ${error}`);

--- a/tests/converters/ffmpeg.test.ts
+++ b/tests/converters/ffmpeg.test.ts
@@ -191,6 +191,7 @@ test("passes a maxBuffer above the 1 MB default so long conversions don't overfl
 
   // execFile's default maxBuffer is 1 MB; ffmpeg's progress output on a long
   // encode exceeds it and the conversion fails with "stderr maxBuffer length
-  // exceeded". The fix raises it well above the default.
-  expect(lastOptions?.maxBuffer).toBeGreaterThan(1024 * 1024);
+  // exceeded". Lock in the raised buffer (must match FFMPEG_MAX_BUFFER in
+  // ffmpeg.ts) so a regression to a smaller-but-still-over-1-MB value is caught.
+  expect(lastOptions?.maxBuffer).toBe(1024 * 1024 * 64);
 });

--- a/tests/converters/ffmpeg.test.ts
+++ b/tests/converters/ffmpeg.test.ts
@@ -1,14 +1,18 @@
 import { beforeEach, expect, test } from "bun:test";
 import { convert } from "../../src/converters/ffmpeg";
+import type { ExecFileOptions } from "node:child_process";
 
 let calls: string[][] = [];
+let lastOptions: ExecFileOptions | undefined;
 
 function mockExecFile(
   _cmd: string,
   args: string[],
+  options: ExecFileOptions,
   callback: (err: Error | null, stdout: string, stderr: string) => void,
 ) {
   calls.push(args);
+  lastOptions = options;
   if (args.includes("fail.mov")) {
     callback(new Error("mock failure"), "", "Fake stderr: fail");
   } else {
@@ -18,6 +22,7 @@ function mockExecFile(
 
 beforeEach(() => {
   calls = [];
+  lastOptions = undefined;
   delete process.env.FFMPEG_ARGS;
 });
 
@@ -168,6 +173,7 @@ test("logs stderr when execFile returns only stderr and no error", async () => {
   const mockExecFileStderrOnly = (
     _cmd: string,
     _args: string[],
+    _options: ExecFileOptions,
     callback: (err: Error | null, stdout: string, stderr: string) => void,
   ) => {
     callback(null, "", "Only stderr output");
@@ -178,4 +184,13 @@ test("logs stderr when execFile returns only stderr and no error", async () => {
   console.error = originalConsoleError;
 
   expect(loggedMessage).toBe("stderr: Only stderr output");
+});
+
+test("passes a maxBuffer above the 1 MB default so long conversions don't overflow stderr (#565)", async () => {
+  await convert("in.mkv", "mkv", "h264.mp4", "out.mp4", undefined, mockExecFile);
+
+  // execFile's default maxBuffer is 1 MB; ffmpeg's progress output on a long
+  // encode exceeds it and the conversion fails with "stderr maxBuffer length
+  // exceeded". The fix raises it well above the default.
+  expect(lastOptions?.maxBuffer).toBeGreaterThan(1024 * 1024);
 });


### PR DESCRIPTION
ffmpeg conversions of long inputs fail with `Error: stderr maxBuffer length exceeded` (#565).

The ffmpeg converter calls `execFile("ffmpeg", ...)` with no options, so it uses Node's default maxBuffer of 1 MB for stdout and stderr. ffmpeg writes continuous progress to stderr, and on a long encode (the report was a 3h39m h264 job) that output passes 1 MB, so Node kills the process and the conversion fails. This raises the ffmpeg maxBuffer to 64 MB.

One detail worth flagging: the options object has to go before the callback. Node's `execFile` ignores an options argument placed after the callback, so passing `{ maxBuffer }` as a fourth argument compiles and can pass a mocked test but has no effect in production. The shared `ExecFileFn` type declared options last, which is the trap, so this uses a small local function type with the correct argument order.

Added a regression test asserting the ffmpeg `execFile` call receives a maxBuffer above the 1 MB default; it fails if the options argument is removed. `bun test tests/converters/ffmpeg.test.ts` passes with ffmpeg.ts at 100% coverage, and tsc, eslint, and prettier are clean on the changed files.

Fixes #565

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes ffmpeg conversions of long inputs that previously failed with `stderr maxBuffer length exceeded`; `execFile` now allows sustained progress output instead of terminating at Node’s 1 MB default (#565).

- Sets the ffmpeg buffer to exactly 64 MB.
- Passes the options before the callback and tests the exact value to prevent regressions.

<sup>Written for commit c866f1ea15fd840ec83b3d9c3e84093efd0f0aad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/C4illin/ConvertX/pull/629?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

