### PR TITLE
docs: say what to back up, and why mydb.sqlite alone is not enough

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ Then visit `http://localhost:3000` in your browser and create your account. Don'
 
 If you get unable to open database file run `chown -R $USER:$USER path` on the path you choose.
 
+To back up ConvertX, back up the whole `data` directory. It holds `mydb.sqlite` together with its `-wal` file, where recent rows live until SQLite checkpoints them, and the `uploads/` and `output/` directories holding the files your conversion jobs refer to. Copying `mydb.sqlite` alone gives you an instance you cannot log in to.
+
 ### Environment variables
 
 All are optional, JWT_SECRET is recommended to be set.


### PR DESCRIPTION
One paragraph under Deployment saying what to back up: the whole `data` directory, because `mydb.sqlite` on its own is missing the rows still in its `-wal` and the files under `uploads/` and `output/` are not in the database at all. Tested on v0.18.0: restoring `mydb.sqlite` alone gives an instance that answers 403 at login; restoring the directory restores everything.

Closes #630.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds backup guidance to the README explaining that the whole `data` directory must be backed up, not just `mydb.sqlite`.

- `mydb.sqlite` alone is missing the `-wal` file with recent rows and the `uploads/` and `output/` files, so restoring only it leaves an instance that returns 403 at login.
- Closes #630.

<sup>Written for commit 144d10f64a2ba8c5245d9bcba92fe79441d8fc86. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/C4illin/ConvertX/pull/631?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

