### PR TITLE
fix(graphicsmagick): apply EXIF auto-orient so portrait images don't convert sideways (#590)

### DIFF
--- a/src/converters/graphicsmagick.ts
+++ b/src/converters/graphicsmagick.ts
@@ -317,8 +317,10 @@ export function convert(
   options?: unknown,
   execFile: ExecFileFn = execFileOriginal, // to make it mockable
 ): Promise<string> {
+  // Apply EXIF orientation so photos (e.g. from phones) don't end up sideways
+  // when converted to formats where the orientation tag is lost or ignored
   return new Promise((resolve, reject) => {
-    execFile("gm", ["convert", filePath, targetPath], (error, stdout, stderr) => {
+    execFile("gm", ["convert", filePath, "-auto-orient", targetPath], (error, stdout, stderr) => {
       if (error) {
         reject(`error: ${error}`);
       }

--- a/tests/converters/graphicsmagick.test.ts
+++ b/tests/converters/graphicsmagick.test.ts
@@ -1,7 +1,32 @@
-import { test } from "bun:test";
+import { beforeEach, expect, test } from "bun:test";
+import type { ExecFileException } from "node:child_process";
 import { convert } from "../../src/converters/graphicsmagick";
+import { ExecFileFn } from "../../src/converters/types";
 import { runCommonTests } from "./helpers/commonTests";
+
+let calls: string[][] = [];
+
+beforeEach(() => {
+  calls = [];
+});
 
 runCommonTests(convert);
 
-test.skip("dummy - required to trigger test detection", () => {});
+test("convert applies EXIF auto-orient", async () => {
+  let command = "";
+  const mockExecFile: ExecFileFn = (
+    cmd: string,
+    args: string[],
+    callback: (err: ExecFileException | null, stdout: string, stderr: string) => void,
+  ) => {
+    command = cmd;
+    calls.push(args);
+    callback(null, "", "");
+  };
+
+  const result = await convert("input.jpg", "jpg", "pdf", "output.pdf", undefined, mockExecFile);
+
+  expect(result).toBe("Done");
+  expect(command).toBe("gm");
+  expect(calls[0]).toEqual(["convert", "input.jpg", "-auto-orient", "output.pdf"]);
+});


### PR DESCRIPTION
Fixes #590.

A phone portrait photo is stored as landscape pixels plus an EXIF Orientation tag (for example Orientation 6, rotate 90). Converting it with the GraphicsMagick converter produced a landscape result, because `gm convert` was called without `-auto-orient` and the target format (PDF here) drops the orientation tag.

#577 fixed this for the ImageMagick converter by adding `-auto-orient`. This does the same for the GraphicsMagick converter, which is one of the paths the reporter mentions ("ImageMagick or others").

Reproduced with the exact command the converter runs, on a 600x400 JPEG tagged EXIF Orientation 6:
- `gm convert in.jpg out.pdf` produced a 600x400 (landscape) PDF page
- `gm convert in.jpg -auto-orient out.pdf` produced a 400x600 (portrait) PDF page

A genuinely portrait-pixel image (400x600, no EXIF) already converted to a portrait PDF, so this is specifically EXIF orientation, not page geometry. `-auto-orient` is a no-op on images with no orientation tag.

Test: mirrors the imagemagick test added in #577, asserting the `gm convert` args are `["convert", filePath, "-auto-orient", targetPath]`. It fails without the change.

One note: like #577, this applies `-auto-orient` to every GraphicsMagick conversion. If you would rather scope it (some formats and targets can carry the orientation tag themselves, so they may not need it), I am happy to adjust.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #590 by adding `-auto-orient` to the GraphicsMagick converter. Phone portrait photos (landscape pixels plus an EXIF orientation tag) previously converted to landscape when the target format dropped the tag; now they keep their orientation.

- Mirrors the ImageMagick converter fix from #577.
- `-auto-orient` is a no-op on images without an orientation tag.

<sup>Written for commit 567c58572cdb36cfdd5c190f444eebf6a0a0cfc0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/C4illin/ConvertX/pull/637?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

