### PR TITLE
ci: add autofix.ci

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -1,0 +1,20 @@
+name: autofix.ci
+on:
+  pull_request:
+  push:
+    branches: ["main"]
+permissions:
+  contents: read
+
+jobs:
+  autofix:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.2.2
+      - run: bun i
+      - run: bun run format
+      - uses: autofix-ci/action@c5b2d67aa2274e7b5a18224e8171550871fc7e4a

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -17,6 +17,8 @@ jobs:
       - uses: actions/checkout@v7
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.2.2
 
       - name: Install dependencies
         run: bun install

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -6,6 +6,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   autofix:
     runs-on: ubuntu-latest
@@ -13,8 +17,12 @@ jobs:
       - uses: actions/checkout@v7
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: 1.2.2
-      - run: bun i
-      - run: bun run format
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Format code
+        run: |
+          bun run format:eslint || true
+          bun run format:prettier
       - uses: autofix-ci/action@c5b2d67aa2274e7b5a18224e8171550871fc7e4a

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.2.2
+          bun-version-file: ".bun-version"
 
       - name: Install dependencies
         run: bun install

--- a/.github/workflows/check-lint.yml
+++ b/.github/workflows/check-lint.yml
@@ -23,8 +23,6 @@ jobs:
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: 1.2.2
 
       - name: Install dependencies
         run: bun install

--- a/.github/workflows/check-lint.yml
+++ b/.github/workflows/check-lint.yml
@@ -23,6 +23,8 @@ jobs:
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.2.2
 
       - name: Install dependencies
         run: bun install

--- a/.github/workflows/check-lint.yml
+++ b/.github/workflows/check-lint.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.2.2
+          bun-version-file: ".bun-version"
 
       - name: Install dependencies
         run: bun install

--- a/.github/workflows/run-bun-test.yml
+++ b/.github/workflows/run-bun-test.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.2.2
+          bun-version-file: ".bun-version"
 
       - name: Install dependencies
         run: bun install


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds an autofix.ci workflow that runs ESLint and Prettier on pull requests and pushes to main, so style fixes are applied automatically. Both lint and test workflows now read the Bun version from `.bun-version` instead of hardcoding 1.2.2.

<sup>Written for commit d70469b1c116ee37d4ac4a5419cfb1a476c5ac5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/C4illin/ConvertX/pull/644?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

